### PR TITLE
feat: add graduation timeline lounge redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
-# Riesling Site (Warm Lounge Edition)
+# 1206 心灵休憩小客厅（毕业季版）
 
-A lightweight Flask application that offers a cozy landing page, a simple video player for media stored in `/opt/video`, and a guestbook that writes visitor notes to `/etc/data/messages.log` so the host can collect them via a bind mount.
+一个轻盈的 Flask 单页应用，用温柔的蓝色基调收纳这段旅程：首页呈现暖心问候、互动式时间轴、
+位于 `/opt/video` 的视频播放器，以及写入 `/etc/data/messages.log` 的留言本，方便通过挂载目录在宿主机上收集。
 
 ## Features
 
-- **Warm single-page UI** optimised for low resource usage inside the container.
-- **Video playback** for files located in `/opt/video` (mount a host folder there to supply media).
-- **Minimal guestbook** that stores submissions with UTC timestamps on the host.
-- **Health probe** available at `/health` for container orchestration.
+- **温馨首页**：更新为浅蓝色背景与毕业季主题文案。
+- **心动时间册**：时间戳式互动元素，可逐一查看每个阶段的插图或占位图，方便替换成真实照片与视频。
+- **视频播放器**：读取 `/opt/video` 中的媒体文件，40M 的毕业季影片挂载后会自动出现。
+- **留言本**：访客留言保存至宿主机绑定的目录，并附带 UTC 时间戳。
+- **健康检查**：`/health` 端点可用于容器编排探测。
 
 ## Prerequisites
 
@@ -54,21 +56,19 @@ image. From the project root, run:
 docker build -t riesling-site .
 ```
 
-Start the container with any volumes you need mounted for media playback or the
-guestbook log. The example below exposes the web application, mounts a host
-folder with videos as read-only, and mounts a directory for guestbook entries:
+启动容器时记得挂载所需目录，这样媒体与留言才能被持久化。下面的命令示例包含详细参数说明：
 
 ```bash
 docker run \
-  --name riesling-site \
-  -p 1206:1206 \
-  -v /var/host-videos:/opt/video:ro \
-  -v /var/nextchat:/etc/data \
+  --name 1206-lounge \
+  --publish 1206:1206 \
+  --env TZ=Asia/Shanghai \
+  --mount type=bind,src=/srv/grad-memory/videos,dst=/opt/video,ro \
+  --mount type=bind,src=/srv/grad-memory/messages,dst=/etc/data \
+  --restart unless-stopped \
   riesling-site
 ```
 
-- Videos copied to `/var/host-videos` on the host appear in the drop-down list
-  in the UI.
-- Guestbook submissions append to `/var/nextchat/messages.log` on the host.
-- Stop the container with `docker stop riesling-site` and remove it with
-  `docker rm riesling-site` when you are done.
+- 将 40M 的毕业季 MP4 拷贝到 `/srv/grad-memory/videos` 后，播放器会在下拉列表中显示它。
+- 留言内容会写入 `/srv/grad-memory/messages/messages.log`，可随时在宿主机查看或备份。
+- 使用 `docker stop 1206-lounge` 停止容器，如需删除可运行 `docker rm 1206-lounge`。

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,11 +1,11 @@
 :root {
-  --bg-gradient: linear-gradient(135deg, #fde5ec, #fff6e5);
-  --card-bg: rgba(255, 255, 255, 0.85);
-  --primary: #f07b72;
-  --primary-dark: #d95e57;
-  --text: #52382f;
-  --muted: #927c72;
-  --shadow: 0 20px 45px rgba(210, 142, 129, 0.25);
+  --bg-gradient: linear-gradient(135deg, #cfe8ff, #f4f9ff);
+  --card-bg: rgba(255, 255, 255, 0.9);
+  --primary: #3a7bd5;
+  --primary-dark: #2d63ad;
+  --text: #1f3558;
+  --muted: #53759d;
+  --shadow: 0 20px 45px rgba(74, 128, 185, 0.18);
   --radius-lg: 28px;
   font-size: 16px;
 }
@@ -33,7 +33,7 @@ body {
 .hero__content {
   max-width: 680px;
   margin: 0 auto;
-  background: rgba(255, 255, 255, 0.6);
+  background: rgba(255, 255, 255, 0.75);
   border-radius: var(--radius-lg);
   padding: 2.5rem 2rem;
   box-shadow: var(--shadow);
@@ -64,6 +64,10 @@ body {
   padding: 2.25rem;
   box-shadow: var(--shadow);
   backdrop-filter: blur(10px);
+}
+
+.card--timeline {
+  overflow: hidden;
 }
 
 .card h2 {
@@ -145,6 +149,86 @@ body {
   line-height: 1.6;
 }
 
+.timeline {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 1.75rem;
+}
+
+.timeline__nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.timeline__item {
+  border: none;
+  background: rgba(58, 123, 213, 0.14);
+  color: var(--primary-dark);
+  padding: 0.75rem 1.35rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.timeline__item:focus {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(58, 123, 213, 0.25);
+}
+
+.timeline__item:hover,
+.timeline__item.timeline__item--active {
+  background: var(--primary);
+  color: #fff;
+}
+
+.timeline__panels {
+  position: relative;
+  min-height: 360px;
+}
+
+.timeline__panel {
+  display: none;
+  animation: fadeIn 0.45s ease;
+}
+
+.timeline__panel--active {
+  display: block;
+}
+
+.timeline__figure {
+  display: grid;
+  gap: 1rem;
+}
+
+.timeline__figure img {
+  width: 100%;
+  border-radius: 24px;
+  box-shadow: 0 12px 32px rgba(74, 128, 185, 0.15);
+}
+
+.timeline__figure--grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.timeline__figure figcaption {
+  font-size: 1rem;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 .feedback {
   margin-top: 1.25rem;
   min-height: 1.5rem;
@@ -182,5 +266,14 @@ body {
 
   .card {
     padding: 1.75rem;
+  }
+
+  .timeline__nav {
+    gap: 0.5rem;
+  }
+
+  .timeline__item {
+    flex: 1 1 calc(50% - 0.5rem);
+    text-align: center;
   }
 }

--- a/static/img/timeline/2021-01-journey.svg
+++ b/static/img/timeline/2021-01-journey.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 640">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#84b7ff" />
+      <stop offset="100%" stop-color="#d7e8ff" />
+    </linearGradient>
+    <linearGradient id="card" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.8" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0.6" />
+    </linearGradient>
+  </defs>
+  <rect width="960" height="640" rx="42" fill="url(#bg)" />
+  <g opacity="0.65">
+    <circle cx="160" cy="160" r="38" fill="#ffffff" />
+    <circle cx="220" cy="460" r="28" fill="#ffffff" />
+    <circle cx="720" cy="120" r="44" fill="#ffffff" />
+    <circle cx="810" cy="430" r="34" fill="#ffffff" />
+  </g>
+  <g transform="translate(130 120)">
+    <rect width="700" height="420" rx="32" fill="url(#card)" stroke="#b8d7ff" stroke-width="3" />
+    <g transform="translate(60 60)">
+      <text x="0" y="0" font-family="'Noto Sans SC', 'PingFang SC', sans-serif" font-size="54" font-weight="700" fill="#2263b8">
+        2021年1月
+      </text>
+      <text x="0" y="82" font-family="'Noto Sans SC', 'PingFang SC', sans-serif" font-size="30" fill="#356abf">
+        蓝色的日历翻开旅程的第一页
+      </text>
+      <rect x="0" y="120" width="580" height="260" rx="26" fill="#edf4ff" stroke="#b8d7ff" stroke-width="2" />
+      <g transform="translate(30 170)">
+        <rect x="0" y="0" width="140" height="110" rx="20" fill="#9cc7ff" opacity="0.6" />
+        <rect x="160" y="0" width="140" height="110" rx="20" fill="#6eaefc" opacity="0.8" />
+        <rect x="320" y="0" width="140" height="110" rx="20" fill="#4898fa" opacity="0.9" />
+        <rect x="480" y="0" width="40" height="110" rx="18" fill="#2c80ef" opacity="0.9" />
+      </g>
+      <text x="20" y="360" font-family="'Noto Sans SC', 'PingFang SC', sans-serif" font-size="24" fill="#2c5f9e">
+        那时我们一起为梦想排定日程，每一格都写着光亮。
+      </text>
+    </g>
+  </g>
+</svg>

--- a/static/img/timeline/2021-06-office-a.svg
+++ b/static/img/timeline/2021-06-office-a.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 640">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#c1e3ff" />
+      <stop offset="100%" stop-color="#f6fbff" />
+    </linearGradient>
+  </defs>
+  <rect width="960" height="640" rx="46" fill="url(#bg)" />
+  <g fill="#ffffff" opacity="0.7">
+    <rect x="80" y="80" width="800" height="480" rx="36" />
+  </g>
+  <g transform="translate(120 140)">
+    <rect x="0" y="0" width="720" height="360" rx="28" fill="#eff7ff" stroke="#b7d8ff" stroke-width="3" />
+    <rect x="40" y="40" width="280" height="220" rx="24" fill="#ffffff" stroke="#9ec7ff" stroke-width="2" />
+    <rect x="360" y="40" width="280" height="220" rx="24" fill="#ffffff" stroke="#9ec7ff" stroke-width="2" />
+    <g transform="translate(60 70)" opacity="0.9">
+      <rect x="0" y="0" width="90" height="150" rx="12" fill="#d0e6ff" />
+      <rect x="100" y="0" width="120" height="150" rx="12" fill="#a7ccff" />
+      <rect x="230" y="0" width="40" height="150" rx="12" fill="#7fb4ff" />
+    </g>
+    <g transform="translate(380 70)" opacity="0.95">
+      <rect x="0" y="0" width="220" height="60" rx="12" fill="#63a0f2" />
+      <rect x="0" y="70" width="220" height="40" rx="10" fill="#8bb7f7" />
+      <rect x="0" y="120" width="220" height="40" rx="10" fill="#bad7ff" />
+    </g>
+    <text x="0" y="320" font-family="'Noto Sans SC', 'PingFang SC', sans-serif" font-size="48" font-weight="700" fill="#2360a8">
+      2021年6月 · 办公室窗边
+    </text>
+    <text x="0" y="360" font-family="'Noto Sans SC', 'PingFang SC', sans-serif" font-size="26" fill="#437fc9">
+      窗外的绿与玻璃上映出的期待相互映衬。
+    </text>
+  </g>
+</svg>

--- a/static/img/timeline/2021-06-office-b.svg
+++ b/static/img/timeline/2021-06-office-b.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 640">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#d3ecff" />
+      <stop offset="100%" stop-color="#fdfdff" />
+    </linearGradient>
+  </defs>
+  <rect width="960" height="640" rx="50" fill="url(#bg)" />
+  <g transform="translate(120 120)">
+    <rect width="720" height="400" rx="32" fill="#ffffff" opacity="0.9" />
+    <rect x="40" y="60" width="640" height="220" rx="24" fill="#e8f3ff" stroke="#a8cdf7" stroke-width="3" />
+    <g transform="translate(70 100)" opacity="0.85">
+      <rect x="0" y="0" width="520" height="70" rx="16" fill="#9cc6ff" />
+      <rect x="0" y="90" width="520" height="70" rx="16" fill="#b7d8ff" />
+    </g>
+    <g transform="translate(620 20)" opacity="0.75">
+      <rect width="50" height="160" rx="12" fill="#6eabf7" />
+    </g>
+    <text x="40" y="40" font-family="'Noto Sans SC', 'PingFang SC', sans-serif" font-size="48" font-weight="700" fill="#215a9f">
+      2021年6月 · 教室走廊
+    </text>
+    <text x="40" y="340" font-family="'Noto Sans SC', 'PingFang SC', sans-serif" font-size="26" fill="#3c76ba">
+      玻璃隔断后的灯光仍然温柔，我们的脚步没有停下。
+    </text>
+  </g>
+</svg>

--- a/static/img/timeline/2022-03-teatime.svg
+++ b/static/img/timeline/2022-03-teatime.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 640">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#cde7ff" />
+      <stop offset="100%" stop-color="#f5fbff" />
+    </linearGradient>
+    <radialGradient id="steam" cx="50%" cy="0%" r="70%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.75" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="960" height="640" rx="48" fill="url(#bg)" />
+  <g transform="translate(120 120)">
+    <rect width="720" height="400" rx="36" fill="#ffffff" opacity="0.85" />
+    <text x="60" y="90" font-family="'Noto Sans SC', 'PingFang SC', sans-serif" font-size="52" font-weight="700" fill="#2a6bb6">
+      2022年3月 · 温茶一盏
+    </text>
+    <text x="60" y="140" font-family="'Noto Sans SC', 'PingFang SC', sans-serif" font-size="26" fill="#407bd4">
+      我们在案前歇脚，未来也在这一杯回甘里慢慢沉淀。
+    </text>
+    <g transform="translate(180 160)">
+      <ellipse cx="220" cy="220" rx="220" ry="70" fill="#b7d7ff" opacity="0.55" />
+      <ellipse cx="220" cy="220" rx="170" ry="55" fill="#e0ecff" />
+      <path d="M120 160c0-60 200-60 200 0v90H120z" fill="#ffffff" stroke="#9ec7ff" stroke-width="4" />
+      <path d="M320 170c35 0 60 25 60 60s-25 60-60 60" fill="none" stroke="#5e9ff5" stroke-width="16" stroke-linecap="round" />
+      <circle cx="320" cy="208" r="16" fill="#ffffff" stroke="#5e9ff5" stroke-width="6" />
+      <ellipse cx="220" cy="200" rx="120" ry="26" fill="#e6f1ff" />
+      <ellipse cx="160" cy="90" rx="32" ry="80" fill="url(#steam)" />
+      <ellipse cx="220" cy="60" rx="28" ry="100" fill="url(#steam)" opacity="0.8" />
+      <ellipse cx="280" cy="100" rx="24" ry="70" fill="url(#steam)" opacity="0.75" />
+    </g>
+  </g>
+</svg>

--- a/static/img/timeline/2023-12-video.svg
+++ b/static/img/timeline/2023-12-video.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 640">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#b8d9ff" />
+      <stop offset="100%" stop-color="#f3f8ff" />
+    </linearGradient>
+    <linearGradient id="screen" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#3578d4" />
+      <stop offset="100%" stop-color="#5aa6ff" />
+    </linearGradient>
+  </defs>
+  <rect width="960" height="640" rx="48" fill="url(#bg)" />
+  <g transform="translate(140 120)">
+    <rect width="680" height="360" rx="36" fill="#ffffff" opacity="0.85" />
+    <rect x="60" y="70" width="560" height="260" rx="26" fill="url(#screen)" />
+    <polygon points="370,200 260,140 260,260" fill="#ffffff" opacity="0.92" />
+    <circle cx="120" cy="220" r="36" fill="#ffffff" opacity="0.25" />
+    <circle cx="600" cy="120" r="28" fill="#ffffff" opacity="0.35" />
+    <text x="40" y="30" font-family="'Noto Sans SC', 'PingFang SC', sans-serif" font-size="48" font-weight="700" fill="#215aa1">
+      2023年12月6日 · 视频待入场
+    </text>
+    <text x="40" y="420" font-family="'Noto Sans SC', 'PingFang SC', sans-serif" font-size="26" fill="#3e76bd">
+      40M 的回忆影片将放在宿主机指定目录，待挂载后自动亮起。
+    </text>
+  </g>
+</svg>

--- a/static/img/timeline/2024-01-terminal.svg
+++ b/static/img/timeline/2024-01-terminal.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 640">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#a1c9ff" />
+      <stop offset="100%" stop-color="#eff6ff" />
+    </linearGradient>
+    <linearGradient id="sign" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#1b4f99" />
+      <stop offset="100%" stop-color="#2c6ecf" />
+    </linearGradient>
+  </defs>
+  <rect width="960" height="640" rx="48" fill="url(#bg)" />
+  <g transform="translate(140 120)">
+    <rect width="680" height="360" rx="36" fill="#ffffff" opacity="0.85" />
+    <g transform="translate(200 80)">
+      <rect x="0" y="0" width="320" height="220" rx="28" fill="url(#sign)" />
+      <text x="160" y="80" font-family="'Noto Sans SC', 'PingFang SC', sans-serif" font-size="48" font-weight="700" fill="#ffffff" text-anchor="middle">
+        T3
+      </text>
+      <text x="160" y="130" font-family="'Noto Sans SC', 'PingFang SC', sans-serif" font-size="28" fill="#cde4ff" text-anchor="middle">
+        航站楼
+      </text>
+      <text x="160" y="174" font-family="'Noto Sans SC', 'PingFang SC', sans-serif" font-size="24" fill="#ffde59" text-anchor="middle">
+        指向未来的箭头
+      </text>
+      <polygon points="160,210 120,250 200,250" fill="#ffde59" />
+    </g>
+    <text x="40" y="40" font-family="'Noto Sans SC', 'PingFang SC', sans-serif" font-size="48" font-weight="700" fill="#1f5aa8">
+      2024年1月31日 · 终点亦是起点
+    </text>
+    <text x="40" y="420" font-family="'Noto Sans SC', 'PingFang SC', sans-serif" font-size="26" fill="#3a74c1">
+      航站楼灯牌下，我们把心里的祝福默默整理好。
+    </text>
+  </g>
+</svg>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -4,6 +4,8 @@ document.addEventListener("DOMContentLoaded", () => {
   const player = document.getElementById("video-player");
   const feedback = document.getElementById("guestbook-feedback");
   const form = document.getElementById("guestbook-form");
+  const timelineItems = document.querySelectorAll(".timeline__item");
+  const timelinePanels = document.querySelectorAll(".timeline__panel");
 
   const setFeedback = (message, isError = false) => {
     if (!feedback) return;
@@ -67,6 +69,48 @@ document.addEventListener("DOMContentLoaded", () => {
           submitButton.textContent = "送出温暖";
         }
       }
+    });
+  }
+
+  if (timelineItems.length > 0 && timelinePanels.length > 0) {
+    const activateTimeline = (targetId) => {
+      timelinePanels.forEach((panel) => {
+        const isActive = panel.id === targetId;
+        panel.classList.toggle("timeline__panel--active", isActive);
+        panel.setAttribute("aria-hidden", String(!isActive));
+      });
+
+      timelineItems.forEach((item) => {
+        const isActive = item.dataset.target === targetId;
+        item.classList.toggle("timeline__item--active", isActive);
+        item.setAttribute("aria-pressed", String(isActive));
+      });
+    };
+
+    const defaultActive = document.querySelector(".timeline__item.timeline__item--active");
+    if (defaultActive?.dataset.target) {
+      activateTimeline(defaultActive.dataset.target);
+    } else if (timelineItems[0]?.dataset.target) {
+      activateTimeline(timelineItems[0].dataset.target);
+    }
+
+    timelineItems.forEach((item) => {
+      item.addEventListener("click", () => {
+        const targetId = item.dataset.target;
+        if (targetId) {
+          activateTimeline(targetId);
+        }
+      });
+
+      item.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          const targetId = item.dataset.target;
+          if (targetId) {
+            activateTimeline(targetId);
+          }
+        }
+      });
     });
   }
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>温馨的葡萄园</title>
+    <title>1206心灵休憩小客厅（毕业季版）</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -19,10 +19,10 @@
   <body>
     <header class="hero">
       <div class="hero__content">
-        <h1>欢迎来到 Riesling 的小客厅</h1>
+        <h1>1206心灵休憩小客厅（毕业季版）</h1>
         <p>
-          在这里，您可以放松地欣赏家庭视频，也可以给未来的自己留下一句悄悄话。
-          我们为镜像进行了轻量化配置，让它在任何机器上都能安静地运行。
+          在最忙的日子里也要记得按下暂停键。这里收藏了我们共同的光影、书写和轻声问候，
+          轻轻播放就能回到彼此身边。容器保持轻盈，却装得下满满的温度。
         </p>
       </div>
     </header>
@@ -47,6 +47,81 @@
         {% else %}
         <p class="empty">目前还没有可播放的视频。把文件放到 /opt/video 中再刷新试试吧！</p>
         {% endif %}
+      </section>
+
+      <section class="card card--timeline" aria-labelledby="timeline-heading">
+        <h2 id="timeline-heading">🕰️ 心动时间册</h2>
+        <p>
+          像翻阅日记一样，从每一个时间戳里收好故事。点击时间点即可查看对应的图片或提醒，
+          让我们一起回望这段旅程的沿途风景。
+        </p>
+        <div class="timeline">
+          <nav class="timeline__nav" aria-label="旅程时序">
+            <button type="button" class="timeline__item timeline__item--active" data-target="moment-2021-01">2021 年 1 月</button>
+            <button type="button" class="timeline__item" data-target="moment-2021-06">2021 年 6 月</button>
+            <button type="button" class="timeline__item" data-target="moment-2022-03">2022 年 3 月</button>
+            <button type="button" class="timeline__item" data-target="moment-2023-12">2023 年 12 月 6 日</button>
+            <button type="button" class="timeline__item" data-target="moment-2024-01">2024 年 1 月 31 日</button>
+          </nav>
+          <div class="timeline__panels">
+            <article id="moment-2021-01" class="timeline__panel timeline__panel--active" aria-hidden="false">
+              <figure class="timeline__figure">
+                <img
+                  src="{{ url_for('static', filename='img/timeline/2021-01-journey.svg') }}"
+                  alt="2021年1月的蓝色日程页，记录着起步的愿望"
+                />
+                <figcaption>我们按下了第一颗日程上的星星，也按下了梦想的开场键。</figcaption>
+              </figure>
+            </article>
+
+            <article id="moment-2021-06" class="timeline__panel" aria-hidden="true">
+              <figure class="timeline__figure timeline__figure--grid">
+                <img
+                  src="{{ url_for('static', filename='img/timeline/2021-06-office-a.svg') }}"
+                  alt="2021年6月在办公室窗边休憩的画面"
+                />
+                <img
+                  src="{{ url_for('static', filename='img/timeline/2021-06-office-b.svg') }}"
+                  alt="2021年6月在教室走廊准备课程的画面"
+                />
+                <figcaption>盛夏的玻璃窗映着光，我们在教室与办公室之间奔跑着长大。</figcaption>
+              </figure>
+            </article>
+
+            <article id="moment-2022-03" class="timeline__panel" aria-hidden="true">
+              <figure class="timeline__figure">
+                <img
+                  src="{{ url_for('static', filename='img/timeline/2022-03-teatime.svg') }}"
+                  alt="2022年3月泡茶歇息的温柔瞬间"
+                />
+                <figcaption>三月的茶香和回甘，提醒我们在匆忙中也别忘了安静地照顾彼此。</figcaption>
+              </figure>
+            </article>
+
+            <article id="moment-2023-12" class="timeline__panel" aria-hidden="true">
+              <figure class="timeline__figure">
+                <img
+                  src="{{ url_for('static', filename='img/timeline/2023-12-video.svg') }}"
+                  alt="2023年12月即将上线的视频占位图"
+                />
+                <figcaption>
+                  40M 的毕业季影片已经在待机区，等你把宿主机目录挂载到 <code>/opt/video</code>，
+                  它就会在播放列表里闪亮登场。
+                </figcaption>
+              </figure>
+            </article>
+
+            <article id="moment-2024-01" class="timeline__panel" aria-hidden="true">
+              <figure class="timeline__figure">
+                <img
+                  src="{{ url_for('static', filename='img/timeline/2024-01-terminal.svg') }}"
+                  alt="2024年1月31日航站楼指引牌的照片"
+                />
+                <figcaption>在航站楼的指示牌下，我们向彼此挥手，知道前行的路上依然同行。</figcaption>
+              </figure>
+            </article>
+          </div>
+        </div>
       </section>
 
       <section class="card">


### PR DESCRIPTION
## Summary
- refresh the landing experience with the new graduation-season branding and messaging
- add an interactive timeline component with illustrative assets and accessibility states
- document the updated docker run workflow for mounting media and guestbook directories

## Testing
- python -m compileall .

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917a338f9b8832a86e57c8b74839312)