### PR TITLE
Add graduation timeline and update lounge theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
-# Riesling Site (Warm Lounge Edition)
+# 1206 心灵休憩小客厅（毕业季版）
 
-A lightweight Flask application that offers a cozy landing page, a simple video player for media stored in `/opt/video`, and a guestbook that writes visitor notes to `/etc/data/messages.log` so the host can collect them via a bind mount.
+一个轻盈的 Flask 单页应用，承载毕业季的小客厅：
+
+- 温柔的浅蓝色背景与留言区，让大家在 1206 的记忆里继续休憩。
+- 时间线元素记录 2021~2024 的重要瞬间，支持你替换为真实照片或视频。
+- 视频播放器会读取 `/opt/video` 里的媒体文件，随时播放你想分享的片段。
+- 留言会写入 `/etc/data/messages.log`，方便在宿主机上留存祝福。
 
 ## Features
 
-- **Warm single-page UI** optimised for low resource usage inside the container.
-- **Video playback** for files located in `/opt/video` (mount a host folder there to supply media).
+- **Blue & calm single-page UI** tuned for 低资源占用，适合在轻量容器里运行。
+- **Timeline diary** with interactive milestones. Replace the SVG 占位图（位于 `static/img/timeline`）即可展示你的真实照片。
+- **Video playback** for files located in `/opt/video` (including `2023-12-06-graduation.mp4` for the timeline video spot).
 - **Minimal guestbook** that stores submissions with UTC timestamps on the host.
 - **Health probe** available at `/health` for container orchestration.
 
@@ -54,21 +60,22 @@ image. From the project root, run:
 docker build -t riesling-site .
 ```
 
-Start the container with any volumes you need mounted for media playback or the
-guestbook log. The example below exposes the web application, mounts a host
-folder with videos as read-only, and mounts a directory for guestbook entries:
+启动容器时，请把视频目录和留言目录都挂载进去。下面给出一个包含详细参数的示例：
 
 ```bash
 docker run \
   --name riesling-site \
+  --restart unless-stopped \
   -p 1206:1206 \
-  -v /var/host-videos:/opt/video:ro \
-  -v /var/nextchat:/etc/data \
+  -e VIDEO_DIRECTORY="/opt/video" \
+  -e DATA_DIRECTORY="/etc/data" \
+  -v /path/on/host/videos:/opt/video:rw \
+  -v /path/on/host/guestbook:/etc/data:rw \
   riesling-site
 ```
 
-- Videos copied to `/var/host-videos` on the host appear in the drop-down list
-  in the UI.
-- Guestbook submissions append to `/var/nextchat/messages.log` on the host.
-- Stop the container with `docker stop riesling-site` and remove it with
-  `docker rm riesling-site` when you are done.
+- `VIDEO_DIRECTORY` 会告诉应用去哪个目录读取视频。示例中把宿主机的 `/path/on/host/videos` 挂载到了 `/opt/video`，其中的文件会同时出现在播放器下拉框和“2023 年 12 月 6 日”时间轴的影片占位中（文件命名为 `2023-12-06-graduation.mp4` 时即可直接播放）。
+- `DATA_DIRECTORY` 决定留言日志放在哪里。示例挂载后，可在宿主机的 `/path/on/host/guestbook/messages.log` 查看记录。
+- 需要停止服务时执行 `docker stop riesling-site`，如需删除容器再运行 `docker rm riesling-site`。
+
+如果你想保留原始 SVG 插画并替换为真实照片，只需把同名图片放进容器的 `static/img/timeline` 中即可覆盖显示。

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,11 +1,11 @@
 :root {
-  --bg-gradient: linear-gradient(135deg, #fde5ec, #fff6e5);
-  --card-bg: rgba(255, 255, 255, 0.85);
-  --primary: #f07b72;
-  --primary-dark: #d95e57;
-  --text: #52382f;
-  --muted: #927c72;
-  --shadow: 0 20px 45px rgba(210, 142, 129, 0.25);
+  --bg-gradient: linear-gradient(135deg, #d7ecff, #f0f7ff);
+  --card-bg: rgba(255, 255, 255, 0.88);
+  --primary: #3a7bd5;
+  --primary-dark: #265fa6;
+  --text: #1f3d5a;
+  --muted: #5a7390;
+  --shadow: 0 22px 48px rgba(38, 95, 166, 0.2);
   --radius-lg: 28px;
   font-size: 16px;
 }
@@ -33,7 +33,7 @@ body {
 .hero__content {
   max-width: 680px;
   margin: 0 auto;
-  background: rgba(255, 255, 255, 0.6);
+  background: rgba(255, 255, 255, 0.7);
   border-radius: var(--radius-lg);
   padding: 2.5rem 2rem;
   box-shadow: var(--shadow);
@@ -64,6 +64,7 @@ body {
   padding: 2.25rem;
   box-shadow: var(--shadow);
   backdrop-filter: blur(10px);
+  border: 1px solid rgba(58, 123, 213, 0.08);
 }
 
 .card h2 {
@@ -84,8 +85,8 @@ body {
   width: 100%;
   padding: 0.85rem 1rem;
   border-radius: 16px;
-  border: 1px solid rgba(240, 123, 114, 0.35);
-  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(58, 123, 213, 0.25);
+  background: rgba(255, 255, 255, 0.85);
   font-size: 1rem;
   color: var(--text);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
@@ -96,7 +97,7 @@ body {
 .textarea:focus {
   outline: none;
   border-color: var(--primary);
-  box-shadow: 0 0 0 4px rgba(240, 123, 114, 0.15);
+  box-shadow: 0 0 0 4px rgba(58, 123, 213, 0.18);
 }
 
 .textarea {
@@ -134,7 +135,7 @@ body {
 .button:focus {
   background: var(--primary-dark);
   transform: translateY(-2px);
-  box-shadow: 0 15px 25px rgba(240, 123, 114, 0.25);
+  box-shadow: 0 15px 25px rgba(58, 123, 213, 0.2);
   outline: none;
 }
 
@@ -171,6 +172,140 @@ body {
   color: var(--muted);
 }
 
+.timeline {
+  position: relative;
+  overflow: hidden;
+}
+
+.timeline__intro {
+  margin-bottom: 1.5rem;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.timeline__container {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.timeline__nav {
+  flex: 1 1 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.timeline__marker {
+  border: 1px solid rgba(58, 123, 213, 0.3);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--text);
+  border-radius: 18px;
+  padding: 0.9rem 1.1rem;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.timeline__marker:hover,
+.timeline__marker:focus {
+  border-color: var(--primary);
+  box-shadow: 0 10px 24px rgba(58, 123, 213, 0.18);
+  transform: translateY(-2px);
+  outline: none;
+}
+
+.timeline__marker--active {
+  background: linear-gradient(120deg, rgba(58, 123, 213, 0.12), rgba(58, 123, 213, 0.28));
+  border-color: var(--primary);
+}
+
+.timeline__date {
+  font-weight: 700;
+  color: var(--primary-dark);
+}
+
+.timeline__title {
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.timeline__entries {
+  flex: 2 1 320px;
+  position: relative;
+}
+
+.timeline__entry {
+  display: none;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.timeline__entry--active {
+  display: flex;
+}
+
+.timeline__entry h3 {
+  font-size: 1.35rem;
+  color: var(--primary-dark);
+}
+
+.timeline__figure {
+  width: 100%;
+  border-radius: 22px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(58, 123, 213, 0.12);
+  box-shadow: 0 18px 28px rgba(15, 57, 102, 0.12);
+}
+
+.timeline__figure img,
+.timeline__figure video {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.timeline__figure--grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.timeline__placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  padding: 3rem 1.5rem;
+  background: linear-gradient(135deg, rgba(58, 123, 213, 0.15), rgba(58, 123, 213, 0.05));
+  color: var(--primary-dark);
+  font-weight: 600;
+  text-align: center;
+}
+
+.timeline__placeholder-icon {
+  font-size: 2.5rem;
+}
+
+.timeline__placeholder-text {
+  font-size: 1.05rem;
+}
+
+.timeline__video {
+  border-radius: 22px;
+  border: 1px solid rgba(58, 123, 213, 0.12);
+  box-shadow: 0 18px 28px rgba(15, 57, 102, 0.12);
+  margin-top: 0.5rem;
+}
+
+.timeline__entry p {
+  line-height: 1.8;
+}
+
 @media (max-width: 720px) {
   .hero {
     padding-top: 2.5rem;
@@ -182,5 +317,19 @@ body {
 
   .card {
     padding: 1.75rem;
+  }
+
+  .timeline__container {
+    flex-direction: column;
+  }
+
+  .timeline__nav {
+    flex-direction: row;
+    overflow-x: auto;
+    padding-bottom: 0.5rem;
+  }
+
+  .timeline__marker {
+    min-width: 180px;
   }
 }

--- a/static/img/timeline/2021-01-calendar.svg
+++ b/static/img/timeline/2021-01-calendar.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 520" role="img" aria-labelledby="title desc">
+  <title id="title">2021年1月的蓝色课程表</title>
+  <desc id="desc">蓝色渐变背景上的日历页面，突出显示一月的温暖计划。</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#7bc6ff" />
+      <stop offset="100%" stop-color="#d4e9ff" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="520" fill="url(#bg)" rx="32" />
+  <g transform="translate(120 90)">
+    <rect width="560" height="360" rx="28" fill="rgba(255,255,255,0.86)" />
+    <rect x="0" y="0" width="560" height="90" rx="28" fill="#3a7bd5" />
+    <text x="40" y="58" font-size="42" font-family="'Noto Sans SC', 'PingFang SC', sans-serif" fill="#ffffff" font-weight="600">2021 · JAN</text>
+    <g transform="translate(40 120)" fill="#3a7bd5" opacity="0.68">
+      <g font-size="24" fill="#3a7bd5" font-family="'Noto Sans SC', 'PingFang SC', sans-serif">
+        <text x="0" y="0">Mon</text>
+        <text x="72" y="0">Tue</text>
+        <text x="150" y="0">Wed</text>
+        <text x="228" y="0">Thu</text>
+        <text x="312" y="0">Fri</text>
+        <text x="396" y="0">Sat</text>
+        <text x="474" y="0">Sun</text>
+      </g>
+      <g stroke="#3a7bd5" stroke-width="3" fill="none" opacity="0.35">
+        <rect x="-12" y="24" width="88" height="64" rx="16" />
+        <rect x="66" y="24" width="88" height="64" rx="16" />
+        <rect x="144" y="24" width="88" height="64" rx="16" />
+        <rect x="222" y="24" width="88" height="64" rx="16" />
+        <rect x="300" y="24" width="88" height="64" rx="16" />
+        <rect x="378" y="24" width="88" height="64" rx="16" />
+        <rect x="456" y="24" width="88" height="64" rx="16" />
+      </g>
+      <g fill="#3a7bd5" opacity="0.5">
+        <circle cx="32" cy="56" r="6" />
+        <circle cx="108" cy="56" r="6" />
+        <circle cx="344" cy="56" r="6" />
+        <circle cx="420" cy="56" r="6" />
+        <circle cx="496" cy="56" r="6" />
+        <circle cx="184" cy="56" r="6" />
+      </g>
+      <g fill="#3a7bd5" opacity="0.8" font-size="20" font-family="'Noto Sans SC', 'PingFang SC', sans-serif">
+        <text x="-4" y="122">口语彩排</text>
+        <text x="150" y="122">模拟面试</text>
+        <text x="306" y="122">写作打卡</text>
+      </g>
+    </g>
+  </g>
+  <text x="400" y="470" font-size="32" text-anchor="middle" fill="rgba(0,0,0,0.45)" font-family="'Noto Sans SC', 'PingFang SC', sans-serif">蓝色的日程表带来新年的希望</text>
+</svg>

--- a/static/img/timeline/2021-06-office-1.svg
+++ b/static/img/timeline/2021-06-office-1.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 520" role="img" aria-labelledby="title desc">
+  <title id="title">2021年6月 前厅落地窗</title>
+  <desc id="desc">柔和蓝绿色调的插画，描绘阳光洒入的前厅与圆桌。</desc>
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#9fd2ff" />
+      <stop offset="100%" stop-color="#d9f1ff" />
+    </linearGradient>
+    <linearGradient id="floor" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f3f9ff" />
+      <stop offset="100%" stop-color="#d7e5f4" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="520" fill="url(#sky)" rx="32" />
+  <rect x="50" y="260" width="700" height="200" fill="url(#floor)" opacity="0.85" />
+  <g opacity="0.8">
+    <rect x="120" y="90" width="140" height="260" fill="rgba(255,255,255,0.8)" />
+    <rect x="280" y="90" width="140" height="260" fill="rgba(255,255,255,0.9)" />
+    <rect x="440" y="90" width="140" height="260" fill="rgba(255,255,255,0.8)" />
+    <rect x="600" y="90" width="80" height="260" fill="rgba(255,255,255,0.7)" />
+  </g>
+  <g opacity="0.3" fill="#3a7bd5">
+    <rect x="130" y="110" width="120" height="220" />
+    <rect x="290" y="110" width="120" height="220" />
+    <rect x="450" y="110" width="120" height="220" />
+  </g>
+  <g>
+    <ellipse cx="320" cy="320" rx="120" ry="42" fill="rgba(74, 119, 181, 0.2)" />
+    <ellipse cx="320" cy="310" rx="110" ry="26" fill="#ffffff" />
+    <rect x="290" y="244" width="60" height="72" fill="#4f7db6" rx="16" />
+    <rect x="360" y="244" width="60" height="72" fill="#6991c8" rx="16" />
+    <rect x="300" y="262" width="40" height="46" fill="#ffffff" opacity="0.8" rx="10" />
+  </g>
+  <g transform="translate(520 280)">
+    <ellipse cx="0" cy="80" rx="90" ry="36" fill="rgba(74, 119, 181, 0.2)" />
+    <rect x="-36" y="0" width="72" height="88" rx="22" fill="#5fa6a6" />
+    <rect x="-26" y="18" width="52" height="48" rx="16" fill="#ffffff" opacity="0.85" />
+    <rect x="70" y="-50" width="22" height="180" rx="10" fill="#7dc47d" />
+    <circle cx="81" cy="-68" r="44" fill="#9be19b" />
+  </g>
+  <text x="400" y="470" font-size="30" text-anchor="middle" fill="rgba(24,58,92,0.65)" font-family="'Noto Sans SC','PingFang SC',sans-serif">午后的阳光与圆桌陪你讨论每一个小细节</text>
+</svg>

--- a/static/img/timeline/2021-06-office-2.svg
+++ b/static/img/timeline/2021-06-office-2.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 520" role="img" aria-labelledby="title desc">
+  <title id="title">2021年6月 玻璃隔断的工位</title>
+  <desc id="desc">描绘办公室玻璃隔断、绿植与干净地面的插画。</desc>
+  <defs>
+    <linearGradient id="bg2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#b6e1ff" />
+      <stop offset="100%" stop-color="#f0f8ff" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="520" fill="url(#bg2)" rx="32" />
+  <g opacity="0.85">
+    <rect x="90" y="70" width="620" height="320" fill="rgba(255,255,255,0.9)" rx="26" />
+    <rect x="140" y="120" width="520" height="240" fill="rgba(227,240,255,0.75)" rx="22" />
+  </g>
+  <g fill="#3a7bd5" opacity="0.35">
+    <rect x="170" y="130" width="12" height="220" />
+    <rect x="340" y="130" width="12" height="220" />
+    <rect x="510" y="130" width="12" height="220" />
+  </g>
+  <g>
+    <rect x="200" y="190" width="90" height="110" fill="#ffffff" rx="18" />
+    <rect x="210" y="200" width="70" height="60" fill="#ffbf80" rx="14" />
+    <rect x="380" y="190" width="110" height="110" fill="#ffffff" rx="18" />
+    <rect x="395" y="200" width="82" height="60" fill="#8ad1ff" rx="14" />
+    <rect x="560" y="190" width="90" height="110" fill="#ffffff" rx="18" />
+    <rect x="572" y="200" width="66" height="60" fill="#a9e6c8" rx="14" />
+  </g>
+  <g>
+    <rect x="210" y="310" width="60" height="10" fill="#c1d7f1" />
+    <rect x="390" y="310" width="60" height="10" fill="#c1d7f1" />
+    <rect x="570" y="310" width="60" height="10" fill="#c1d7f1" />
+  </g>
+  <g>
+    <ellipse cx="140" cy="360" rx="48" ry="20" fill="rgba(90, 173, 133, 0.2)" />
+    <rect x="124" y="290" width="28" height="78" rx="12" fill="#6fb68f" />
+    <circle cx="138" cy="280" r="44" fill="#8fd8ac" />
+  </g>
+  <g>
+    <ellipse cx="660" cy="360" rx="44" ry="18" fill="rgba(90, 173, 133, 0.2)" />
+    <rect x="644" y="300" width="28" height="70" rx="12" fill="#6fb68f" />
+    <circle cx="658" cy="290" r="36" fill="#8fd8ac" />
+  </g>
+  <text x="400" y="470" font-size="30" text-anchor="middle" fill="rgba(31,61,90,0.65)" font-family="'Noto Sans SC','PingFang SC',sans-serif">玻璃折射出六月的光，也装进了满满的期待</text>
+</svg>

--- a/static/img/timeline/2022-03-tea.svg
+++ b/static/img/timeline/2022-03-tea.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 520" role="img" aria-labelledby="title desc">
+  <title id="title">2022年3月 茶香与键盘</title>
+  <desc id="desc">温暖的茶具插画，呈现手冲茶的瞬间。</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#e0f2ff" />
+      <stop offset="100%" stop-color="#f6fbff" />
+    </linearGradient>
+    <radialGradient id="steam" cx="0.5" cy="0.2" r="0.6">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.9)" />
+      <stop offset="100%" stop-color="rgba(255,255,255,0)" />
+    </radialGradient>
+  </defs>
+  <rect width="800" height="520" fill="url(#bg)" rx="32" />
+  <ellipse cx="400" cy="380" rx="220" ry="90" fill="rgba(58,123,213,0.12)" />
+  <g transform="translate(200 160)">
+    <ellipse cx="200" cy="180" rx="140" ry="48" fill="#f9f3eb" />
+    <ellipse cx="200" cy="176" rx="110" ry="32" fill="#f0e4d3" />
+    <ellipse cx="200" cy="172" rx="80" ry="22" fill="#d8b38c" />
+    <g opacity="0.9">
+      <path d="M170 60 h60 l10 110 q-40 18 -80 0z" fill="#f0f5ff" stroke="#c4d9f7" stroke-width="4" stroke-linejoin="round" />
+      <ellipse cx="200" cy="70" rx="40" ry="16" fill="#c4d9f7" />
+      <ellipse cx="200" cy="64" rx="36" ry="12" fill="#eff5ff" />
+    </g>
+    <g>
+      <path d="M110 132 q60 -50 110 -18 q50 32 110 -18" fill="none" stroke="#ffe1b8" stroke-width="10" stroke-linecap="round" opacity="0.4" />
+    </g>
+    <g opacity="0.85">
+      <ellipse cx="320" cy="120" rx="32" ry="12" fill="#d8b38c" />
+      <ellipse cx="320" cy="118" rx="26" ry="8" fill="#f5e5d1" />
+      <path d="M300 40 h40 l12 70 q-32 12 -64 0z" fill="#f5f1ea" stroke="#e4d6c2" stroke-width="3" />
+    </g>
+    <g opacity="0.35">
+      <ellipse cx="200" cy="-10" rx="46" ry="38" fill="url(#steam)" />
+      <ellipse cx="240" cy="-30" rx="36" ry="30" fill="url(#steam)" />
+    </g>
+    <rect x="-40" y="210" width="480" height="18" fill="#dce7f7" rx="9" />
+  </g>
+  <text x="400" y="470" font-size="32" text-anchor="middle" fill="rgba(31,61,90,0.6)" font-family="'Noto Sans SC','PingFang SC',sans-serif">热茶的香气提醒我们：别忘了善待自己</text>
+</svg>

--- a/static/img/timeline/2024-01-31-terminal.svg
+++ b/static/img/timeline/2024-01-31-terminal.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 520" role="img" aria-labelledby="title desc">
+  <title id="title">2024年1月31日 航站楼指引牌</title>
+  <desc id="desc">夜色中的航站楼指引牌，带有温暖的指向箭头。</desc>
+  <defs>
+    <linearGradient id="night" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1a2c4f" />
+      <stop offset="100%" stop-color="#132036" />
+    </linearGradient>
+    <linearGradient id="glow" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffe36d" />
+      <stop offset="100%" stop-color="#ff9c4a" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="520" fill="url(#night)" rx="32" />
+  <g opacity="0.25" fill="#ffffff">
+    <circle cx="120" cy="120" r="4" />
+    <circle cx="220" cy="80" r="3" />
+    <circle cx="400" cy="60" r="5" />
+    <circle cx="620" cy="110" r="4" />
+    <circle cx="700" cy="160" r="3" />
+  </g>
+  <g>
+    <rect x="300" y="60" width="160" height="400" rx="24" fill="#111d33" stroke="#20365c" stroke-width="4" />
+    <rect x="320" y="100" width="120" height="90" rx="16" fill="url(#glow)" />
+    <rect x="320" y="210" width="120" height="70" rx="16" fill="#1f3561" />
+    <rect x="320" y="300" width="120" height="70" rx="16" fill="#1f3561" />
+    <rect x="320" y="390" width="120" height="40" rx="16" fill="#1f3561" />
+    <path d="M332 250 h52 l16 16 l-16 16 h-52z" fill="#ffd56a" />
+    <path d="M332 335 h52 l16 16 l-16 16 h-52z" fill="#ffd56a" />
+    <text x="380" y="152" font-size="40" text-anchor="middle" fill="#1a2c4f" font-weight="700" font-family="'Noto Sans SC','PingFang SC',sans-serif">T3</text>
+    <text x="380" y="188" font-size="20" text-anchor="middle" fill="#1a2c4f" font-family="'Noto Sans SC','PingFang SC',sans-serif">航站楼</text>
+    <text x="380" y="246" font-size="20" text-anchor="middle" fill="#e6efff" font-family="'Noto Sans SC','PingFang SC',sans-serif">城际铁路</text>
+    <text x="380" y="286" font-size="16" text-anchor="middle" fill="#97b5e8" font-family="'Noto Sans SC','PingFang SC',sans-serif">前往地铁</text>
+    <text x="380" y="326" font-size="20" text-anchor="middle" fill="#e6efff" font-family="'Noto Sans SC','PingFang SC',sans-serif">P 停车场</text>
+    <text x="380" y="406" font-size="16" text-anchor="middle" fill="#97b5e8" font-family="'Noto Sans SC','PingFang SC',sans-serif">B1 · B2</text>
+  </g>
+  <g opacity="0.25" fill="#1f3561">
+    <rect x="170" y="340" width="120" height="20" rx="10" />
+    <rect x="520" y="360" width="150" height="24" rx="12" />
+  </g>
+  <text x="400" y="470" font-size="30" text-anchor="middle" fill="#d0e3ff" font-family="'Noto Sans SC','PingFang SC',sans-serif">航站楼的灯亮着，等你们平安启程</text>
+</svg>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -4,6 +4,10 @@ document.addEventListener("DOMContentLoaded", () => {
   const player = document.getElementById("video-player");
   const feedback = document.getElementById("guestbook-feedback");
   const form = document.getElementById("guestbook-form");
+  const timelineMarkers = Array.from(document.querySelectorAll(".timeline__marker"));
+  const timelineEntries = new Map(
+    Array.from(document.querySelectorAll(".timeline__entry")).map((entry) => [entry.id.replace("timeline-entry-", ""), entry])
+  );
 
   const setFeedback = (message, isError = false) => {
     if (!feedback) return;
@@ -68,5 +72,40 @@ document.addEventListener("DOMContentLoaded", () => {
         }
       }
     });
+  }
+
+  const activateTimelineEntry = (entryId) => {
+    if (!entryId || !timelineEntries.has(entryId)) {
+      return;
+    }
+
+    timelineMarkers.forEach((marker) => {
+      if (marker.dataset.entry === entryId) {
+        marker.classList.add("timeline__marker--active");
+        marker.setAttribute("aria-pressed", "true");
+      } else {
+        marker.classList.remove("timeline__marker--active");
+        marker.setAttribute("aria-pressed", "false");
+      }
+    });
+
+    timelineEntries.forEach((entry, id) => {
+      const isActive = id === entryId;
+      entry.classList.toggle("timeline__entry--active", isActive);
+      entry.setAttribute("aria-hidden", String(!isActive));
+    });
+  };
+
+  if (timelineMarkers.length > 0 && timelineEntries.size > 0) {
+    timelineMarkers.forEach((marker) => {
+      marker.addEventListener("click", () => {
+        activateTimelineEntry(marker.dataset.entry);
+      });
+    });
+
+    const initiallyActive = timelineMarkers.find((marker) => marker.classList.contains("timeline__marker--active"));
+    if (initiallyActive) {
+      activateTimelineEntry(initiallyActive.dataset.entry);
+    }
   }
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>温馨的葡萄园</title>
+    <title>1206心灵休憩小客厅（毕业季版）</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -19,10 +19,10 @@
   <body>
     <header class="hero">
       <div class="hero__content">
-        <h1>欢迎来到 Riesling 的小客厅</h1>
+        <h1>欢迎来到 1206 心灵休憩小客厅（毕业季版）</h1>
         <p>
-          在这里，您可以放松地欣赏家庭视频，也可以给未来的自己留下一句悄悄话。
-          我们为镜像进行了轻量化配置，让它在任何机器上都能安静地运行。
+          这一页蓝色的背景，想陪你回顾一路的心情。慢慢播放那些珍藏的视频，
+          也可以在时间线里轻触每一个脚印，写下给未来的问候。
         </p>
       </div>
     </header>
@@ -43,10 +43,186 @@
             您的浏览器不支持播放此视频。
           </video>
         </div>
-        <p class="hint">提示：使用 Docker 时，将宿主机的 /opt/video 挂载到容器中即可播放。</p>
+        <p class="hint">
+          提示：把宿主机里存放视频的目录挂载到容器的 <code>/opt/video</code>，刷新页面后就能出现在下拉框里。
+        </p>
         {% else %}
         <p class="empty">目前还没有可播放的视频。把文件放到 /opt/video 中再刷新试试吧！</p>
         {% endif %}
+      </section>
+
+      <section class="card timeline">
+        <h2>🕰️ 心情时间线</h2>
+        <p class="timeline__intro">
+          轻点每一个时间戳，就能翻开那段小故事。照片都妥帖地保存着，还留了一个位置等你把 2023 年 12 月 6 日的影片放进来。
+        </p>
+        <div class="timeline__container">
+          <nav class="timeline__nav" aria-label="时间刻度">
+            <button
+              class="timeline__marker timeline__marker--active"
+              type="button"
+              data-entry="2021-01"
+              aria-controls="timeline-entry-2021-01"
+              aria-pressed="true"
+            >
+              <span class="timeline__date">2021 年 1 月</span>
+              <span class="timeline__title">蓝色的日程表</span>
+            </button>
+            <button
+              class="timeline__marker"
+              type="button"
+              data-entry="2021-06"
+              aria-controls="timeline-entry-2021-06"
+              aria-pressed="false"
+            >
+              <span class="timeline__date">2021 年 6 月</span>
+              <span class="timeline__title">办公室的午后</span>
+            </button>
+            <button
+              class="timeline__marker"
+              type="button"
+              data-entry="2022-03"
+              aria-controls="timeline-entry-2022-03"
+              aria-pressed="false"
+            >
+              <span class="timeline__date">2022 年 3 月</span>
+              <span class="timeline__title">茶香与键盘声</span>
+            </button>
+            <button
+              class="timeline__marker"
+              type="button"
+              data-entry="2023-12-06"
+              aria-controls="timeline-entry-2023-12-06"
+              aria-pressed="false"
+            >
+              <span class="timeline__date">2023 年 12 月 6 日</span>
+              <span class="timeline__title">影片的留白</span>
+            </button>
+            <button
+              class="timeline__marker"
+              type="button"
+              data-entry="2024-01-31"
+              aria-controls="timeline-entry-2024-01-31"
+              aria-pressed="false"
+            >
+              <span class="timeline__date">2024 年 1 月 31 日</span>
+              <span class="timeline__title">航站楼的灯</span>
+            </button>
+          </nav>
+
+          <div class="timeline__entries">
+            <article
+              class="timeline__entry timeline__entry--active"
+              id="timeline-entry-2021-01"
+              role="group"
+              aria-labelledby="timeline-entry-2021-01-title"
+              aria-hidden="false"
+            >
+              <header>
+                <h3 id="timeline-entry-2021-01-title">2021 年 1 月 · 新年的课程节奏</h3>
+              </header>
+              <figure class="timeline__figure">
+                <img
+                  src="{{ url_for('static', filename='img/timeline/2021-01-calendar.svg') }}"
+                  alt="一张蓝色渐变背景的课程表，标记着 2021 年 1 月的日程"
+                  loading="lazy"
+                />
+              </figure>
+              <p>那时候的我们，用满满的日程表安排梦想。新的一年从温柔的蓝色里开场。</p>
+            </article>
+
+            <article
+              class="timeline__entry"
+              id="timeline-entry-2021-06"
+              role="group"
+              aria-labelledby="timeline-entry-2021-06-title"
+              aria-hidden="true"
+            >
+              <header>
+                <h3 id="timeline-entry-2021-06-title">2021 年 6 月 · 阳光透进教室</h3>
+              </header>
+              <figure class="timeline__figure timeline__figure--grid">
+                <img
+                  src="{{ url_for('static', filename='img/timeline/2021-06-office-1.svg') }}"
+                  alt="教室前厅的落地窗与圆桌"
+                  loading="lazy"
+                />
+                <img
+                  src="{{ url_for('static', filename='img/timeline/2021-06-office-2.svg') }}"
+                  alt="明亮办公室里整齐的工位与玻璃隔断"
+                  loading="lazy"
+                />
+              </figure>
+              <p>六月的光和小客厅的绿植一起，记录下每次排练、每次讨论还有不止一次的欢笑。</p>
+            </article>
+
+            <article
+              class="timeline__entry"
+              id="timeline-entry-2022-03"
+              role="group"
+              aria-labelledby="timeline-entry-2022-03-title"
+              aria-hidden="true"
+            >
+              <header>
+                <h3 id="timeline-entry-2022-03-title">2022 年 3 月 · 一杯热茶的陪伴</h3>
+              </header>
+              <figure class="timeline__figure">
+                <img
+                  src="{{ url_for('static', filename='img/timeline/2022-03-tea.svg') }}"
+                  alt="桌面上手冲热茶的瞬间"
+                  loading="lazy"
+                />
+              </figure>
+              <p>茶香从杯沿氤氲开来，像是提醒我们在忙碌中也要记得停下来，好好呼吸。</p>
+            </article>
+
+            <article
+              class="timeline__entry"
+              id="timeline-entry-2023-12-06"
+              role="group"
+              aria-labelledby="timeline-entry-2023-12-06-title"
+              aria-hidden="true"
+            >
+              <header>
+                <h3 id="timeline-entry-2023-12-06-title">2023 年 12 月 6 日 · 影片即将上线</h3>
+              </header>
+              <figure class="timeline__figure">
+                <div class="timeline__placeholder" role="img" aria-label="等待上传的毕业纪念视频">
+                  <span class="timeline__placeholder-icon" aria-hidden="true">🎬</span>
+                  <span class="timeline__placeholder-text">40 MB 的毕业季影片待上传</span>
+                </div>
+              </figure>
+              <p>
+                这段 40 MB 的 MP4 还在打磨中。把它命名为 <code>2023-12-06-graduation.mp4</code> 放进
+                <code>/opt/video</code>，时间线就会自动播放。
+              </p>
+              <video class="timeline__video" controls preload="metadata">
+                <source src="/videos/2023-12-06-graduation.mp4" type="video/mp4" />
+                影片上传后刷新页面即可播放。
+              </video>
+            </article>
+
+            <article
+              class="timeline__entry"
+              id="timeline-entry-2024-01-31"
+              role="group"
+              aria-labelledby="timeline-entry-2024-01-31-title"
+              aria-hidden="true"
+            >
+              <header>
+                <h3 id="timeline-entry-2024-01-31-title">2024 年 1 月 31 日 · 在航站楼告别</h3>
+              </header>
+              <figure class="timeline__figure">
+                <img
+                  src="{{ url_for('static', filename='img/timeline/2024-01-31-terminal.svg') }}"
+                  alt="机场航站楼指引牌，箭头指向 2 楼的地铁与停车场"
+                  loading="lazy"
+                />
+              </figure>
+              <p>航站楼的灯光与指引牌见证了分别前的拥抱，也提醒我们：下一段旅程继续前行。</p>
+            </article>
+          </div>
+        </div>
       </section>
 
       <section class="card">
@@ -79,7 +255,7 @@
     </main>
 
     <footer class="footer">
-      <p>期待下一次的相聚。容器默认监听 1206 端口，祝您使用愉快！</p>
+      <p>愿 1206 的小客厅一直为你亮着灯。服务默认监听 1206 端口，随时欢迎回来坐坐。</p>
     </footer>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- restyle the home page with a light blue "1206 心灵休憩小客厅" theme and refreshed copy
- add an interactive milestone timeline with accessible controls, SVG illustrations, and a slot for the upcoming graduation video
- document the new experience in the README, including detailed docker run guidance for mounting videos and guestbook logs

## Testing
- python -m compileall .

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917a338f9b8832a86e57c8b74839312)