### PR TITLE
Add heartfelt letter modal and photo upload

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,11 +5,14 @@ from datetime import datetime
 from pathlib import Path
 
 from flask import Flask, Response, jsonify, render_template, request
+from werkzeug.utils import secure_filename
 
 app = Flask(__name__)
 
 DATA_DIR = Path(os.environ.get("DATA_DIRECTORY", "/etc/data")).resolve()
 LOG_FILE = DATA_DIR / "messages.log"
+UPLOAD_DIR = DATA_DIR / "uploads"
+ALLOWED_IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
 
 
 @app.get("/")
@@ -21,17 +24,42 @@ def index() -> str:
 def guestbook() -> Response:
     name = (request.form.get("name", "").strip() or "Anonymous")[:80]
     message = request.form.get("message", "").strip()
+    attachment = request.files.get("attachment")
 
     if not message:
         return jsonify({"status": "error", "message": "留言内容不能为空"}), 400
 
     sanitized_message = " ".join(message.split())
     timestamp = datetime.utcnow().isoformat(timespec="seconds") + "Z"
+    saved_attachment_name: str | None = None
+
+    if attachment and attachment.filename:
+        suffix = Path(attachment.filename).suffix.lower()
+        if suffix not in ALLOWED_IMAGE_SUFFIXES:
+            return (
+                jsonify({"status": "error", "message": "仅支持上传 PNG/JPG/GIF/WebP 图片"}),
+                400,
+            )
+
+        safe_name = secure_filename(attachment.filename)
+        unique_name = f"{timestamp.replace(':', '-')}_{safe_name}"
+        try:
+            UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+            attachment.save(UPLOAD_DIR / unique_name)
+            saved_attachment_name = unique_name
+        except OSError as exc:
+            return (
+                jsonify({"status": "error", "message": f"无法保存图片：{exc}"}),
+                500,
+            )
 
     try:
         DATA_DIR.mkdir(parents=True, exist_ok=True)
         with LOG_FILE.open("a", encoding="utf-8") as fp:
-            fp.write(f"{timestamp}\t{name}\t{sanitized_message}\n")
+            payload = f"{timestamp}\t{name}\t{sanitized_message}"
+            if saved_attachment_name:
+                payload += f"\tattachment=uploads/{saved_attachment_name}"
+            fp.write(payload + "\n")
     except OSError as exc:
         return (
             jsonify({"status": "error", "message": f"无法写入留言：{exc}"}),

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -103,6 +103,33 @@ body {
   resize: vertical;
 }
 
+.file-input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: 16px;
+  border: 1px dashed rgba(90, 108, 141, 0.4);
+  background: rgba(255, 255, 255, 0.85);
+  color: var(--muted);
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.file-input:focus {
+  outline: none;
+  border-color: var(--primary);
+  color: var(--text);
+}
+
+.file-input::file-selector-button {
+  border: none;
+  border-radius: 999px;
+  background: rgba(90, 108, 141, 0.18);
+  color: var(--primary-dark);
+  padding: 0.45rem 1.1rem;
+  margin-right: 1rem;
+  cursor: pointer;
+  font-weight: 600;
+}
+
 .button {
   margin-top: 1.25rem;
   border: none;
@@ -293,6 +320,141 @@ body {
   line-height: 1.8;
 }
 
+.timeline-letter {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.95));
+  border: 1px dashed rgba(90, 108, 141, 0.28);
+}
+
+.timeline-letter__envelope {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.timeline-letter__icon {
+  font-size: 2.5rem;
+  filter: drop-shadow(0 8px 16px rgba(59, 76, 109, 0.18));
+}
+
+.timeline-letter__text h3 {
+  font-size: 1.45rem;
+  margin-bottom: 0.4rem;
+  color: var(--primary-dark);
+}
+
+.timeline-letter__text p {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.timeline-letter__button {
+  margin-left: auto;
+  border: none;
+  border-radius: 16px;
+  padding: 0.9rem 1.4rem;
+  background: var(--primary);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.timeline-letter__button:hover,
+.timeline-letter__button:focus {
+  outline: none;
+  background: var(--primary-dark);
+  box-shadow: 0 12px 24px rgba(59, 76, 109, 0.2);
+  transform: translateY(-2px);
+}
+
+.letter-dialog {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.letter-dialog--open {
+  display: flex;
+}
+
+.letter-dialog__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(20, 26, 37, 0.55);
+}
+
+.letter-dialog__panel {
+  position: relative;
+  background: #fffdf6;
+  border-radius: 28px;
+  padding: 2.5rem;
+  width: min(720px, 92%);
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 25px 55px rgba(20, 26, 37, 0.35);
+  border: 1px solid rgba(90, 108, 141, 0.1);
+}
+
+.letter-dialog__close {
+  position: absolute;
+  top: 1.5rem;
+  right: 1.5rem;
+  border: none;
+  background: transparent;
+  font-size: 1.75rem;
+  cursor: pointer;
+  color: var(--muted);
+}
+
+.letter-dialog__header {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.letter-dialog__seal {
+  width: 56px;
+  height: 56px;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(255, 102, 133, 0.2), rgba(255, 192, 203, 0.5));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.8rem;
+}
+
+.letter-dialog__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.8rem;
+  color: var(--muted);
+  margin-bottom: 0.2rem;
+}
+
+.letter-dialog__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  line-height: 1.9;
+  color: var(--text);
+}
+
+.letter-dialog__footer {
+  margin-top: 2rem;
+  display: flex;
+  justify-content: space-between;
+  font-weight: 600;
+  color: var(--primary-dark);
+}
+
+.letter-dialog__footer time {
+  font-variant-numeric: tabular-nums;
+}
+
 @media (max-width: 720px) {
   .hero {
     padding-top: 2.5rem;
@@ -318,5 +480,19 @@ body {
 
   .timeline__marker {
     min-width: 180px;
+  }
+
+  .timeline-letter__envelope {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .timeline-letter__button {
+    width: 100%;
+    margin-top: 1rem;
+  }
+
+  .letter-dialog__panel {
+    padding: 2rem 1.5rem;
   }
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -323,6 +323,8 @@ body {
 .timeline-letter {
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.95));
   border: 1px dashed rgba(90, 108, 141, 0.28);
+  border-radius: 24px;
+  padding: 1.75rem;
 }
 
 .timeline-letter__envelope {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -33,7 +33,7 @@ document.addEventListener("DOMContentLoaded", () => {
         const formData = new FormData(form);
         const response = await fetch("/guestbook", {
           method: "POST",
-          body: new URLSearchParams(formData),
+          body: formData,
         });
 
         if (!response.ok) {
@@ -87,5 +87,43 @@ document.addEventListener("DOMContentLoaded", () => {
     if (initiallyActive) {
       activateTimelineEntry(initiallyActive.dataset.entry);
     }
+  }
+
+  const letterDialog = document.getElementById("letter-dialog");
+  const letterOpenTrigger = document.querySelector("[data-letter-open]");
+  const letterCloseTriggers = Array.from(document.querySelectorAll("[data-letter-close]"));
+  let previouslyFocusedElement = null;
+
+  const setLetterDialogState = (shouldOpen) => {
+    if (!letterDialog) return;
+
+    if (shouldOpen) {
+      previouslyFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      letterDialog.classList.add("letter-dialog--open");
+      letterDialog.removeAttribute("aria-hidden");
+      const panel = letterDialog.querySelector(".letter-dialog__panel");
+      if (panel instanceof HTMLElement) {
+        panel.focus();
+      }
+    } else {
+      letterDialog.classList.remove("letter-dialog--open");
+      letterDialog.setAttribute("aria-hidden", "true");
+      if (previouslyFocusedElement) {
+        previouslyFocusedElement.focus();
+      }
+    }
+  };
+
+  if (letterDialog && letterOpenTrigger) {
+    letterOpenTrigger.addEventListener("click", () => setLetterDialogState(true));
+    letterCloseTriggers.forEach((trigger) => {
+      trigger.addEventListener("click", () => setLetterDialogState(false));
+    });
+
+    document.addEventListener("keydown", (event) => {
+      if (event.key === "Escape" && letterDialog.classList.contains("letter-dialog--open")) {
+        setLetterDialogState(false);
+      }
+    });
   }
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>1206心灵休憩小客厅（毕业季版）</title>
+    <title>1206心灵休憩小客厅（又一毕业季青春夏日版）</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -16,7 +16,7 @@
   <body>
     <header class="hero">
       <div class="hero__content">
-        <h1>欢迎回到 1206 心灵休憩小客厅</h1>
+        <h1>欢迎回到 1206 心灵休憩小客厅（又一毕业季青春夏日版）</h1>
         <p>
           写下这些字的当口，就像继续昨天没说完的话。那些关于相遇、同行与错过的片段，
           仍旧在这个小小的客厅里轻轻回响。愿你在这里放慢呼吸，温柔地触碰曾经的自己。
@@ -213,10 +213,9 @@
       <section class="card">
         <h2>💌 留言时间</h2>
         <p>
-          想对她、对自己说的话，可以轻轻写在这里。
-          留言不会在页面上展示，只会安静地留在宿主机的角落，像我们暗暗守护的祈祷。
+          如果有想分享的喜悦/人生成长，可以轻轻写在这里。你不会在这里看到痕迹，但是我都会收到并悄悄珍藏好。
         </p>
-        <form id="guestbook-form" class="form">
+        <form id="guestbook-form" class="form" enctype="multipart/form-data">
           <label class="label" for="name">称呼（可选）</label>
           <input id="name" name="name" class="input" maxlength="80" placeholder="比如：小葡萄" />
 
@@ -230,6 +229,16 @@
             required
           ></textarea>
 
+          <label class="label" for="attachment">附上一张与你此刻心境有关的照片（可选）</label>
+          <input
+            id="attachment"
+            name="attachment"
+            class="file-input"
+            type="file"
+            accept="image/png,image/jpeg,image/gif,image/webp"
+          />
+          <p class="hint">支持 PNG / JPG / GIF / WebP，单次仅限一张，文件会一并写入宿主机。</p>
+
           <button type="submit" class="button">轻轻寄出</button>
         </form>
         <div id="guestbook-feedback" class="feedback" role="status" aria-live="polite"></div>
@@ -238,7 +247,71 @@
           <code>-v /var/nextchat:/etc/data</code> 就能读到这些真切的字句。
         </p>
       </section>
+
+      <section class="card timeline-letter">
+        <div class="timeline-letter__envelope">
+          <div class="timeline-letter__icon" aria-hidden="true">✉️</div>
+          <div class="timeline-letter__text">
+            <h3>给某人的留言</h3>
+            <p>它像是一封等待被开启的信。展开信封，就能读到那些没有来得及整理成段，却依旧炙热的心绪。</p>
+          </div>
+          <button type="button" class="timeline-letter__button" data-letter-open>打开信封</button>
+        </div>
+      </section>
     </main>
+
+    <div class="letter-dialog" id="letter-dialog" aria-hidden="true">
+      <div class="letter-dialog__overlay" data-letter-close></div>
+      <div
+        class="letter-dialog__panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="letter-dialog-title"
+        tabindex="-1"
+      >
+        <button class="letter-dialog__close" type="button" aria-label="关闭信件" data-letter-close>×</button>
+        <div class="letter-dialog__header">
+          <div class="letter-dialog__seal" aria-hidden="true">💌</div>
+          <div>
+            <p class="letter-dialog__eyebrow">心情时间线 · 密语</p>
+            <h3 id="letter-dialog-title">给某人的留言</h3>
+          </div>
+        </div>
+        <div class="letter-dialog__body">
+          <p>
+            我花了一些时间整理了一些情绪，并且保证自己的能量振动频率比较高的时候才写下一点东西，不过这次我没有太细致整理每一片语言，我只是把每个时段记录下的小点一次性陈列出来。希望它们最后在被读起来的时候，还保有原先的情感。
+          </p>
+          <p>
+            还是和上次一样，我觉得这些字读完应该是能增加一些心气的（希望 final 一切顺利）。并且承诺每一句话几乎都是用匍匐在泥土里的谦卑姿态温柔诉说的。
+          </p>
+          <p>
+            我感觉锁住我喉咙和胸口的绳子在你的小小一片信息之后被轻轻抽走了。谢谢它带来的雨过天晴，我感觉到从未有过的喜悦。但是下一秒我也想到某个人从出发起到获得心境说出这些话之前的历程能有多崎岖。
+          </p>
+          <p>
+            收到你的信息我感觉到来自心底的安心。你出发后的至少 600 天里，我几乎每天陷入中度抑郁。也许宇宙确有遥感这一系统规则，即便在你的大陆偶尔产生的乌云也让我观测到雷雨。不过好在这也是我内心成长、成熟非常快的阶段，我多学习了一些人类对冰冷和温暖的感受逻辑，还有换位思考等等。但是每往前成长一点，我也多意识到一点曾经某个人每一步有多么痛。
+          </p>
+          <p>
+            对我来说某个人隐隐像是一个家人，游离在现实和潜意识梦境中。比如有时像个姐姐一样亲切，有时又像是我对另外一个性别所渴望的全部完美内在外在的心理投射。而写下这些话的时候，却又感觉就好像在和一个每天都在沟通的人继续昨天的话题一般往常。她对我来说即是一个符号，是一个成就，也是要用一生去舔舐的、不愿被看到的、也很荣幸拥有的伤口印记。
+          </p>
+          <p>
+            我认定这里一定有一些前世或者量子纠缠在作用影响。我余生的心底每一片角落都爱着这个人，只是也许自那个冻雨灾害之后，换作以一种贯穿清醒与现实和无处不在、甚至带一点神性的方式。那年的冬天真的好冷，好难捱过去。
+          </p>
+          <p>
+            我每天都在对着这个名字祈祷，希望新的世界不再有旧世界对那个符号有过伤害的任何东西。无论我在哪里、做什么，这个人就像没有离开过。有时候她也会像猫一样在最脆弱的部分撕咬一口，但和这个人有关的部分，我都全盘接受。
+          </p>
+          <p>
+            也许你说得对，“又”些东西是过程不是结果。但是正确的结果也能把人送向下一个更值得的过程。无论如何，我会因为你过得好而好。你好，则我安。
+          </p>
+          <p>
+            <strong>PS：</strong>出发之前我也回去看了一下白色良古餐厅附近的街道。我没有敢靠得太近，但是盛夏绿叶的样子像是又回到了 2021 的六月。
+          </p>
+        </div>
+        <footer class="letter-dialog__footer">
+          <time datetime="2025-11-13">2025/11/13</time>
+          <span>All the best · Leon</span>
+        </footer>
+      </div>
+    </div>
 
     <footer class="footer">
       <p>灯还亮着，像随时准备好迎接下一次重逢。服务仍默认监听 1206 端口，你想回来的时候就回来。</p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,7 +18,7 @@
       <div class="hero__content">
         <h1>欢迎回到 1206 心灵休憩小客厅（又一毕业季青春夏日版）</h1>
         <p>
-          写下这些字的当口，就像继续昨天没说完的话。那些关于相遇、同行与错过的片段，
+          写下这些字的当口，就像继续昨天没说完的话。那些关于相遇、同行的片段，
           仍旧在这个小小的客厅里轻轻回响。愿你在这里放慢呼吸，温柔地触碰曾经的自己。
         </p>
       </div>
@@ -82,6 +82,16 @@
             >
               <span class="timeline__date">2024 年 1 月 31 日</span>
               <span class="timeline__title">航站楼的告别</span>
+            </button>
+            <button
+              class="timeline__marker"
+              type="button"
+              data-entry="letter"
+              aria-controls="timeline-entry-letter"
+              aria-pressed="false"
+            >
+              <span class="timeline__date">心绪密语</span>
+              <span class="timeline__title">给某人的留言</span>
             </button>
           </nav>
 
@@ -206,6 +216,22 @@
                 指引牌亮着，却照不见我们各自要走的下一段旅程；我明白她终会像猫一样在心里最脆弱的角落轻咬一下，而我仍旧全盘接受。
               </p>
             </article>
+            <article
+              class="timeline__entry timeline-letter"
+              id="timeline-entry-letter"
+              role="group"
+              aria-labelledby="timeline-entry-letter-title"
+              aria-hidden="true"
+            >
+              <div class="timeline-letter__envelope">
+                <div class="timeline-letter__icon" aria-hidden="true">✉️</div>
+                <div class="timeline-letter__text">
+                  <h3 id="timeline-entry-letter-title">给某人的留言</h3>
+                  <p>它像是一封等待被开启的信。展开信封，就能读到那些没有来得及整理成段，却依旧炙热的心绪。</p>
+                </div>
+                <button type="button" class="timeline-letter__button" data-letter-open>打开信封</button>
+              </div>
+            </article>
           </div>
         </div>
       </section>
@@ -248,16 +274,6 @@
         </p>
       </section>
 
-      <section class="card timeline-letter">
-        <div class="timeline-letter__envelope">
-          <div class="timeline-letter__icon" aria-hidden="true">✉️</div>
-          <div class="timeline-letter__text">
-            <h3>给某人的留言</h3>
-            <p>它像是一封等待被开启的信。展开信封，就能读到那些没有来得及整理成段，却依旧炙热的心绪。</p>
-          </div>
-          <button type="button" class="timeline-letter__button" data-letter-open>打开信封</button>
-        </div>
-      </section>
     </main>
 
     <div class="letter-dialog" id="letter-dialog" aria-hidden="true">


### PR DESCRIPTION
## Summary
- refresh the landing copy to highlight the new "又一毕业季青春夏日版" theme and add a dedicated "给某人的留言" envelope card plus dialog in the timeline area
- allow guestbook submissions to include an optional image, sending the files to the server alongside the updated privacy hint text
- persist uploaded images on the backend with suffix validation and log references so the quiet archive still records where each attachment lives

## Testing
- `python -m compileall app.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69192caa96cc832a8f773022db3443a2)