### PR TITLE
Adjust hero heading layout and guestbook form

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -17,7 +17,8 @@
 }
 
 body {
-  font-family: "Noto Sans SC", "PingFang SC", "Microsoft YaHei", sans-serif;
+  font-family: "SF Pro Display", -apple-system, BlinkMacSystemFont, "PingFang SC",
+    "Noto Sans SC", "Microsoft YaHei", sans-serif;
   min-height: 100vh;
   background: var(--bg-gradient);
   color: var(--text);
@@ -25,6 +26,8 @@ body {
   flex-direction: column;
   position: relative;
   overflow-x: hidden;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
 body::before,
@@ -67,14 +70,24 @@ body::after {
 }
 
 .hero h1 {
-  font-size: 2.45rem;
+  font-size: clamp(1.7rem, 3.6vw, 2.3rem);
   margin-bottom: 1.2rem;
   color: var(--primary-dark);
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.hero__edition {
+  display: block;
+  font-size: clamp(1.05rem, 2.4vw, 1.35rem);
+  font-weight: 600;
+  color: var(--primary);
+  margin-top: 0.25rem;
 }
 
 .hero p {
   line-height: 1.95;
-  font-size: 1.08rem;
+  font-size: clamp(1rem, 1.8vw, 1.14rem);
 }
 
 .main {

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>1206心灵休憩小客厅（毕业备考季节夏日版）</title>
+    <title>1206 专属心灵休憩小客厅（夏日毕业备考季版）</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -16,10 +16,13 @@
   <body>
     <header class="hero">
       <div class="hero__content">
-        <h1>欢迎回到 1206 心灵休憩小客厅（毕业备考季节夏日版）</h1>
+        <h1>
+          欢迎回到 1206 专属心灵休憩小客厅
+          <span class="hero__edition">（夏日毕业备考季版）</span>
+        </h1>
         <p>
           一段消息可能会转瞬即逝，所以我希望能做一些能留存更久的东西，比如说这个小小页面。
-          愿你在这里放慢呼吸，温柔地，略带喜悦地触碰曾经的自己。
+          愿你在这里放慢呼吸，温柔地，略带喜悦地触碰曾经的自己。不必担心，这个网站会一直在。
         </p>
       </div>
     </header>
@@ -181,8 +184,7 @@
                 </div>
               </figure>
               <p>
-                那段 40 MB 的影像还没完成，像是命运留给我们的空白页。
-                也许重要的是过程不是结果，可我仍旧盼着有一天能把它放进这里，让我们认领那份正确的结局。
+                这是 1206 过生日的那一天某个人告诉我不要发送给自己的视频。我轻轻把它放在这里，期待有一天它会被观看。
               </p>
             </article>
 
@@ -233,9 +235,6 @@
           如果有想分享的喜悦/人生成长，可以轻轻写在这里。你不会在这里看到痕迹，但是我都会收到并悄悄珍藏好。
         </p>
         <form id="guestbook-form" class="form" enctype="multipart/form-data">
-          <label class="label" for="name">称呼（可选）</label>
-          <input id="name" name="name" class="input" maxlength="80" placeholder="比如：小葡萄" />
-
           <label class="label" for="message">留言内容</label>
           <textarea
             id="message"


### PR DESCRIPTION
## Summary
- shrink the hero heading and move the edition subtitle onto its own line for clearer hierarchy
- remove the optional name field from the guestbook form so only the message and attachment remain

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919390f6004832aa6a1c76c01febabb)