### PR TITLE
Add automatic video playback support

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,23 +1,62 @@
 from __future__ import annotations
 
+import mimetypes
 import os
 from datetime import datetime
 from pathlib import Path
 
-from flask import Flask, Response, jsonify, render_template, request
+from flask import Flask, Response, abort, jsonify, render_template, request, send_from_directory
 from werkzeug.utils import secure_filename
 
 app = Flask(__name__)
 
 DATA_DIR = Path(os.environ.get("DATA_DIRECTORY", "/etc/data")).resolve()
+VIDEO_DIR = Path(os.environ.get("VIDEO_DIRECTORY", "/opt/video")).resolve()
 LOG_FILE = DATA_DIR / "messages.log"
 UPLOAD_DIR = DATA_DIR / "uploads"
 ALLOWED_IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
+ALLOWED_VIDEO_SUFFIXES = {".mp4", ".webm", ".mov", ".m4v"}
+
+
+def _iter_video_files() -> list[dict[str, str]]:
+    videos: list[dict[str, str]] = []
+    if not VIDEO_DIR.exists():
+        return videos
+
+    try:
+        for entry in sorted(VIDEO_DIR.iterdir()):
+            if not entry.is_file():
+                continue
+            suffix = entry.suffix.lower()
+            if suffix not in ALLOWED_VIDEO_SUFFIXES:
+                continue
+            mime_type = mimetypes.guess_type(entry.name)[0] or "video/mp4"
+            videos.append(
+                {
+                    "name": entry.name,
+                    "display_name": entry.stem.replace("_", " ").replace("-", " "),
+                    "url": f"/videos/{entry.name}",
+                    "mime_type": mime_type,
+                }
+            )
+    except OSError:
+        return videos
+
+    return videos
 
 
 @app.get("/")
 def index() -> str:
-    return render_template("index.html")
+    video_files = _iter_video_files()
+    timeline_video = next((video for video in video_files if video["name"] == "2023-12-06-graduation.mp4"), None)
+    initial_video = timeline_video or (video_files[0] if video_files else None)
+    return render_template(
+        "index.html",
+        video_files=video_files,
+        timeline_video=timeline_video,
+        initial_video=initial_video,
+        video_directory=str(VIDEO_DIR),
+    )
 
 
 @app.post("/guestbook")
@@ -72,6 +111,25 @@ def guestbook() -> Response:
 @app.get("/health")
 def health() -> Response:
     return jsonify({"status": "ok"})
+
+
+@app.get("/videos/<path:filename>")
+def serve_video(filename: str) -> Response:
+    safe_path = Path(filename)
+    if safe_path.is_absolute() or ".." in safe_path.parts:
+        abort(404)
+
+    target = (VIDEO_DIR / safe_path).resolve()
+    try:
+        target.relative_to(VIDEO_DIR)
+    except ValueError:
+        abort(404)
+
+    if not target.exists() or not target.is_file():
+        abort(404)
+
+    relative_path = target.relative_to(VIDEO_DIR)
+    return send_from_directory(VIDEO_DIR, relative_path.as_posix())
 
 
 if __name__ == "__main__":

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -360,6 +360,32 @@ body::after {
   font-size: 2.5rem;
 }
 
+.video-player {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.video-player__header p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.video-player__controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.video-player__video {
+  width: 100%;
+  border-radius: 22px;
+  border: 1px solid rgba(90, 108, 141, 0.12);
+  background: #000;
+  box-shadow: 0 18px 32px rgba(41, 51, 73, 0.14);
+}
+
 .timeline__placeholder-text {
   font-size: 1.05rem;
 }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -172,4 +172,32 @@ document.addEventListener("DOMContentLoaded", () => {
       }
     });
   }
+
+  const videoSelect = document.getElementById("video-select");
+  const videoPlayer = document.getElementById("video-player");
+
+  if (videoSelect && videoPlayer) {
+    videoSelect.addEventListener("change", () => {
+      const selectedOption = videoSelect.selectedOptions[0];
+      if (!selectedOption) {
+        return;
+      }
+
+      const sourceUrl = selectedOption.value;
+      const mimeType = selectedOption.dataset.mimeType || "video/mp4";
+      let sourceElement = videoPlayer.querySelector("source");
+      if (!sourceElement) {
+        sourceElement = document.createElement("source");
+        videoPlayer.appendChild(sourceElement);
+      }
+
+      sourceElement.src = sourceUrl;
+      sourceElement.type = mimeType;
+      videoPlayer.load();
+      const playPromise = videoPlayer.play();
+      if (playPromise && typeof playPromise.catch === "function") {
+        playPromise.catch(() => {});
+      }
+    });
+  }
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -178,10 +178,25 @@
                 <h3 id="timeline-entry-2023-12-06-title">2023 年 12 月 6 日 · 未竟的影片</h3>
               </header>
               <figure class="timeline__figure">
+                {% if timeline_video %}
+                <video
+                  class="timeline__video"
+                  controls
+                  autoplay
+                  muted
+                  loop
+                  playsinline
+                  preload="metadata"
+                >
+                  <source src="{{ timeline_video.url }}" type="{{ timeline_video.mime_type }}" />
+                  这段视频正在静静等待被播放，但当前浏览器似乎不支持 MP4 播放。
+                </video>
+                {% else %}
                 <div class="timeline__placeholder" role="img" aria-label="等待上传的毕业纪念视频">
                   <span class="timeline__placeholder-icon" aria-hidden="true">🎬</span>
                   <span class="timeline__placeholder-text">40 MB 的毕业季影片待上传</span>
                 </div>
+                {% endif %}
               </figure>
               <p>
                 这是 1206 过生日的那一天某个人告诉我不要发送给自己的视频。我轻轻把它放在这里，期待有一天它会被观看。
@@ -227,6 +242,40 @@
             </article>
           </div>
         </div>
+      </section>
+
+      <section class="card video-player" aria-labelledby="video-player-title">
+        <div class="video-player__header">
+          <div>
+            <h2 id="video-player-title">🎬 宿主机影片播放器</h2>
+            <p>把 MP4/MOV/WebM 放进挂载的 {{ video_directory }} 目录，刷新页面后就能在这里播放。</p>
+          </div>
+        </div>
+        {% if initial_video %}
+        <div class="video-player__controls">
+          <label class="label" for="video-select">切换影片</label>
+          <select id="video-select" class="input">
+            {% for video in video_files %}
+            <option value="{{ video.url }}" data-mime-type="{{ video.mime_type }}" {% if video.name == initial_video.name %}selected{% endif %}>
+              {{ video.display_name }}
+            </option>
+            {% endfor %}
+          </select>
+        </div>
+        <video
+          id="video-player"
+          class="video-player__video"
+          controls
+          preload="metadata"
+        >
+          <source src="{{ initial_video.url }}" type="{{ initial_video.mime_type }}" />
+          抱歉，你的浏览器暂不支持 HTML5 视频播放。
+        </video>
+        {% else %}
+        <p class="hint">
+          还没有检测到可以播放的文件。请确认你在启动容器时把宿主机的 `/var/video` 之类的目录挂载到了 `/opt/video`，并放入 MP4/MOV/WebM 文件后刷新即可。
+        </p>
+        {% endif %}
       </section>
 
       <section class="card">


### PR DESCRIPTION
## Summary
- add server-side plumbing to read the mounted video directory, expose the files, and select the graduation clip automatically
- replace the 2023 timeline placeholder with an auto-playing video element and add a reusable video player card with styling
- add client-side logic to switch videos from the dropdown without reloading the page

## Testing
- python -m py_compile app.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69195c214d14832a9942de20ff3ca1e7)