### PR TITLE
Remove host video player and refresh timeline copy

### DIFF
--- a/app.py
+++ b/app.py
@@ -49,13 +49,9 @@ def _iter_video_files() -> list[dict[str, str]]:
 def index() -> str:
     video_files = _iter_video_files()
     timeline_video = next((video for video in video_files if video["name"] == "2023-12-06-graduation.mp4"), None)
-    initial_video = timeline_video or (video_files[0] if video_files else None)
     return render_template(
         "index.html",
-        video_files=video_files,
         timeline_video=timeline_video,
-        initial_video=initial_video,
-        video_directory=str(VIDEO_DIR),
     )
 
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -360,32 +360,6 @@ body::after {
   font-size: 2.5rem;
 }
 
-.video-player {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
-.video-player__header p {
-  margin: 0;
-  color: var(--muted);
-  line-height: 1.6;
-}
-
-.video-player__controls {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.video-player__video {
-  width: 100%;
-  border-radius: 22px;
-  border: 1px solid rgba(90, 108, 141, 0.12);
-  background: #000;
-  box-shadow: 0 18px 32px rgba(41, 51, 73, 0.14);
-}
-
 .timeline__placeholder-text {
   font-size: 1.05rem;
 }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -173,31 +173,4 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
-  const videoSelect = document.getElementById("video-select");
-  const videoPlayer = document.getElementById("video-player");
-
-  if (videoSelect && videoPlayer) {
-    videoSelect.addEventListener("change", () => {
-      const selectedOption = videoSelect.selectedOptions[0];
-      if (!selectedOption) {
-        return;
-      }
-
-      const sourceUrl = selectedOption.value;
-      const mimeType = selectedOption.dataset.mimeType || "video/mp4";
-      let sourceElement = videoPlayer.querySelector("source");
-      if (!sourceElement) {
-        sourceElement = document.createElement("source");
-        videoPlayer.appendChild(sourceElement);
-      }
-
-      sourceElement.src = sourceUrl;
-      sourceElement.type = mimeType;
-      videoPlayer.load();
-      const playPromise = videoPlayer.play();
-      if (playPromise && typeof playPromise.catch === "function") {
-        playPromise.catch(() => {});
-      }
-    });
-  }
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,8 +31,8 @@
       <section class="card timeline">
         <h2>🕰️ 心情时间线</h2>
         <p class="timeline__intro">
-          每一枚时间印章都让我想起，你像家人一样在现实与梦境之间游移。
-          细看这些照片，就像轻轻祈祷她的名字，祈祷那些爱意仍能穿越清醒与潜意识。
+          每一个时间点切片都让我想起，你像家人一样在现实与梦境之间游移。
+          细看这些照片，就像轻轻祈祷她的名字，祈祷那些爱意仍能穿越清醒/潜意识达到新大渌。
         </p>
         <div class="timeline__container">
           <nav class="timeline__nav" aria-label="时间刻度">
@@ -242,40 +242,6 @@
             </article>
           </div>
         </div>
-      </section>
-
-      <section class="card video-player" aria-labelledby="video-player-title">
-        <div class="video-player__header">
-          <div>
-            <h2 id="video-player-title">🎬 宿主机影片播放器</h2>
-            <p>把 MP4/MOV/WebM 放进挂载的 {{ video_directory }} 目录，刷新页面后就能在这里播放。</p>
-          </div>
-        </div>
-        {% if initial_video %}
-        <div class="video-player__controls">
-          <label class="label" for="video-select">切换影片</label>
-          <select id="video-select" class="input">
-            {% for video in video_files %}
-            <option value="{{ video.url }}" data-mime-type="{{ video.mime_type }}" {% if video.name == initial_video.name %}selected{% endif %}>
-              {{ video.display_name }}
-            </option>
-            {% endfor %}
-          </select>
-        </div>
-        <video
-          id="video-player"
-          class="video-player__video"
-          controls
-          preload="metadata"
-        >
-          <source src="{{ initial_video.url }}" type="{{ initial_video.mime_type }}" />
-          抱歉，你的浏览器暂不支持 HTML5 视频播放。
-        </video>
-        {% else %}
-        <p class="hint">
-          还没有检测到可以播放的文件。请确认你在启动容器时把宿主机的 `/var/video` 之类的目录挂载到了 `/opt/video`，并放入 MP4/MOV/WebM 文件后刷新即可。
-        </p>
-        {% endif %}
       </section>
 
       <section class="card">


### PR DESCRIPTION
## Summary
- remove the standalone “宿主机影片播放器” section and its associated assets so the page focuses on the timeline entries while still loading the embedded graduation clip when present
- update the 心情时间线引导文案 to the new wording that mentions“清醒/潜意识达到新大渌”

## Testing
- `python -m py_compile app.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691966f94798832ab929cff96b93ab0f)