### PR TITLE
Refine CD workflow cleanup before redeploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,51 @@
+name: CD on dev merge
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/riesling-site:latest
+
+      - name: Deploy to server
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            IMAGE="${{ secrets.DOCKERHUB_USERNAME }}/riesling-site:latest"
+            docker stop riesling-site || true
+            docker rm riesling-site || true
+            docker rmi "$IMAGE" || true
+            docker pull "$IMAGE"
+            docker run -itd \
+              --name riesling-site \
+              --restart unless-stopped \
+              -p 1206:1206 \
+              -e VIDEO_DIRECTORY="/opt/video" \
+              -e DATA_DIRECTORY="/etc/data" \
+              -v /var/video:/opt/video:rw \
+              -v /var/nextchat:/etc/data:rw \
+              "$IMAGE"


### PR DESCRIPTION
## Summary
- stop and remove existing riesling-site container before redeployment
- remove the previous image to ensure the latest version is pulled
- start the refreshed container with interactive detached flags and existing settings

## Testing
- not run (workflow-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b762b3dfc832a8f55296467d9f0af)