### PR TITLE
Remove export preview button

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -143,13 +143,6 @@ body::after {
   z-index: 1;
 }
 
-.utility-bar {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  gap: 0.75rem;
-}
-
 .card {
   background: var(--card-bg);
   border-radius: var(--radius-lg);
@@ -420,11 +413,6 @@ body::after {
   background: rgba(31, 111, 180, 0.1);
   color: var(--primary-dark);
   box-shadow: none;
-}
-
-.utility-bar .button {
-  margin-top: 0;
-  padding-inline: 1.4rem;
 }
 
 .hint {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -10,7 +10,6 @@ document.addEventListener("DOMContentLoaded", () => {
   );
   const toolSecretContainer = document.getElementById("tool-share-secret");
   const toolRevealButton = document.querySelector("[data-tool-reveal]");
-  const exportPreviewButton = document.querySelector("[data-export-preview]");
 
   const setFeedback = (message, isError = false) => {
     if (!feedback) return;
@@ -136,12 +135,6 @@ document.addEventListener("DOMContentLoaded", () => {
     if (initiallyActive) {
       activateTimelineEntry(initiallyActive.dataset.entry);
     }
-  }
-
-  if (exportPreviewButton) {
-    exportPreviewButton.addEventListener("click", () => {
-      window.print();
-    });
   }
 
   const escapeHtml = (value) =>

--- a/templates/index.html
+++ b/templates/index.html
@@ -38,9 +38,6 @@
     </header>
 
     <main class="main">
-      <div class="utility-bar">
-        <button class="button button--secondary" type="button" data-export-preview>导出预览</button>
-      </div>
 
       <section class="card encouragement" aria-labelledby="encouragement-title">
         <div class="encouragement__media">


### PR DESCRIPTION
## Summary
- remove the export preview button from the page layout
- clean up related styles and JavaScript listener for the export control

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e14842264832aa0212dd798c2a266)