### PR TITLE
Embed wandering video inline and refresh messaging

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -592,7 +592,7 @@ body::after {
   line-height: 1.8;
 }
 
-.timeline__cta {
+.timeline__cta { 
   display: flex;
   flex-direction: column;
   gap: 0.85rem;
@@ -606,6 +606,19 @@ body::after {
   margin: 0;
   color: var(--primary-dark);
   font-weight: 600;
+}
+
+.timeline__cta-video {
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(90, 108, 141, 0.18);
+  box-shadow: 0 12px 24px rgba(41, 51, 73, 0.12);
+}
+
+.timeline__cta-video video {
+  display: block;
+  width: 100%;
+  height: auto;
 }
 
 .timeline__cta-button {

--- a/templates/index.html
+++ b/templates/index.html
@@ -51,7 +51,7 @@
         <div class="encouragement__body">
           <h2 id="encouragement-title">🚉 不要回头 一直向前</h2>
           <p class="encouragement__blessing">
-            就算留恋也不要回头看<br />
+            就算留恋也不要回头<br />
             开往未来的路上<br />
             不该有人在回返。<br />
             请一定保重。
@@ -293,14 +293,12 @@
               {% if wandering_video %}
               <div class="timeline__cta" role="group" aria-label="新的影片入口">
                 <p class="timeline__cta-text">wandering 已经静静安放在这里，随时可以继续播放这段旅程。</p>
-                <a
-                  class="button button--secondary timeline__cta-button"
-                  href="{{ wandering_video.url }}"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  观看 {{ wandering_video.display_name }}
-                </a>
+                <div class="timeline__cta-video">
+                  <video class="timeline__video" controls playsinline preload="metadata">
+                    <source src="{{ wandering_video.url }}" type="{{ wandering_video.mime_type }}" />
+                    wandering 正在等待被播放，但当前浏览器似乎不支持该格式。
+                  </video>
+                </div>
               </div>
               {% endif %}
             </article>


### PR DESCRIPTION
## Summary
- adjust the encouragement blessing text beneath the hero message
- embed the wandering video directly in the December 6 timeline entry for consistent viewing
- style the inline wandering video container to match the timeline aesthetics

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f336cd7dc832a9c3edaa4f4710bbc)