### PR TITLE
Add passcode gate on landing page

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -74,6 +74,120 @@ body {
   outline: none;
 }
 
+
+body.is-locked .hero,
+body.is-locked .main,
+body.is-locked .footer,
+body.is-locked .orientation-tip {
+  filter: blur(6px);
+  pointer-events: none;
+  user-select: none;
+}
+
+.pass-gate {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 80;
+  transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+
+.pass-gate--hidden {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.pass-gate__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 52, 84, 0.45);
+  backdrop-filter: blur(10px) saturate(120%);
+}
+
+.pass-gate__panel {
+  position: relative;
+  z-index: 1;
+  width: min(520px, 92%);
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  border: 1px solid rgba(90, 108, 141, 0.15);
+}
+
+.pass-gate__eyebrow {
+  font-weight: 700;
+  color: var(--primary-dark);
+}
+
+.pass-gate__hint {
+  color: var(--primary);
+  font-weight: 600;
+}
+
+.pass-gate__form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.pass-gate__controls {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.pass-gate__input {
+  flex: 1;
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(23, 50, 75, 0.18);
+  font-size: 1rem;
+  background: rgba(255, 255, 255, 0.85);
+}
+
+.pass-gate__input:focus {
+  outline: 2px solid rgba(31, 111, 180, 0.35);
+  border-color: var(--primary);
+}
+
+.pass-gate__button {
+  white-space: nowrap;
+  padding: 0.8rem 1.2rem;
+}
+
+.pass-gate__feedback {
+  min-height: 1.25rem;
+  color: var(--primary-dark);
+  font-size: 0.95rem;
+}
+
+.pass-gate__feedback--error {
+  color: #b3261e;
+}
+
+.pass-gate__note {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+@media (max-width: 640px) {
+  .pass-gate__controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .pass-gate__button {
+    width: 100%;
+  }
+}
+
 body::before,
 body::after {
   content: "🐋";

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -11,6 +11,63 @@ document.addEventListener("DOMContentLoaded", () => {
   const toolSecretContainer = document.getElementById("tool-share-secret");
   const toolRevealButton = document.querySelector("[data-tool-reveal]");
 
+  const passGate = document.getElementById("pass-gate");
+  const passGateForm = document.getElementById("pass-gate-form");
+  const passGateInput = document.getElementById("pass-gate-input");
+  const passGateFeedback = document.getElementById("pass-gate-feedback");
+  const PASS_GATE_KEY = "pass-gate-unlocked";
+  const allowedPasscodes = ["riesling"];
+
+  const setPassGateMessage = (message, isError = false) => {
+    if (!passGateFeedback) return;
+    passGateFeedback.textContent = message;
+    passGateFeedback.classList.toggle("pass-gate__feedback--error", isError);
+  };
+
+  const togglePassGate = (shouldLock) => {
+    if (!passGate) return;
+    passGate.classList.toggle("pass-gate--hidden", !shouldLock);
+    passGate.setAttribute("aria-hidden", shouldLock ? "false" : "true");
+    document.body.classList.toggle("is-locked", shouldLock);
+    if (shouldLock && passGateInput instanceof HTMLElement) {
+      passGateInput.focus();
+      if (typeof passGateInput.setSelectionRange === "function") {
+        passGateInput.setSelectionRange(0, passGateInput.value.length);
+      }
+    }
+  };
+
+  const validatePasscode = (value) => allowedPasscodes.includes(value.trim().toLowerCase());
+
+  const unlockPassGate = () => {
+    sessionStorage.setItem(PASS_GATE_KEY, "1");
+    togglePassGate(false);
+    setPassGateMessage("");
+  };
+
+  if (passGate) {
+    const unlocked = sessionStorage.getItem(PASS_GATE_KEY) === "1";
+    togglePassGate(!unlocked);
+  } else {
+    document.body.classList.remove("is-locked");
+  }
+
+  if (passGateForm && passGateInput) {
+    passGateForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+      const value = passGateInput.value || "";
+      if (!value.trim()) {
+        setPassGateMessage("需要先输入口令。", true);
+        return;
+      }
+      if (!validatePasscode(value)) {
+        setPassGateMessage("口令和提示不太匹配，再试一次。", true);
+        return;
+      }
+      unlockPassGate();
+    });
+  }
+
   const setFeedback = (message, isError = false) => {
     if (!feedback) return;
     feedback.textContent = message;

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,7 +13,34 @@
     />
     <script defer src="{{ url_for('static', filename='js/app.js') }}"></script>
   </head>
-  <body>
+  <body class="is-locked">
+    <div class="pass-gate" id="pass-gate" aria-hidden="false">
+      <div class="pass-gate__backdrop" aria-hidden="true"></div>
+      <div class="pass-gate__panel" role="dialog" aria-modal="true" aria-labelledby="pass-gate-title">
+        <p class="pass-gate__eyebrow" id="pass-gate-title">🔒 进入前的小小口令</p>
+        <p class="pass-gate__hint">Hint: What's that name starting with letter r?</p>
+        <form class="pass-gate__form" id="pass-gate-form" novalidate>
+          <label class="label pass-gate__label" for="pass-gate-input">口令</label>
+          <div class="pass-gate__controls">
+            <input
+              id="pass-gate-input"
+              class="input pass-gate__input"
+              type="password"
+              name="passcode"
+              inputmode="text"
+              autocomplete="off"
+              spellcheck="false"
+              placeholder="轻轻输入后按 Enter"
+              required
+              aria-describedby="pass-gate-feedback"
+            />
+            <button class="button pass-gate__button" type="submit">进入</button>
+          </div>
+          <p class="pass-gate__feedback" id="pass-gate-feedback" role="status" aria-live="polite"></p>
+        </form>
+        <p class="pass-gate__note">小提示：口令正确会立刻解锁，背景仍能看到熟悉的鲸鱼。</p>
+      </div>
+    </div>
     <div
       class="orientation-tip"
       id="orientation-tip"


### PR DESCRIPTION
## Summary
- add a passcode gate overlay with hint and lock styling to the landing page
- validate the Riesling passcode client-side and remember unlocked state per session
- keep background context visible while preventing interaction until a valid passcode is entered

## Testing
- python -m compileall .

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f86391fe8832a957eefe88adf353c)