### PR TITLE
Add message of the day panel

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -301,6 +301,78 @@ body::after {
   font-size: clamp(1rem, 1.8vw, 1.14rem);
 }
 
+.motd {
+  width: min(960px, 92%);
+  margin: 0 auto 2.5rem;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(233, 245, 255, 0.9));
+  border-radius: var(--radius-lg);
+  padding: 1.75rem 2rem;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(31, 111, 180, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.motd__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.motd__eyebrow {
+  font-weight: 700;
+  color: var(--primary);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.95rem;
+}
+
+.motd h2 {
+  font-size: clamp(1.35rem, 2.4vw, 1.65rem);
+  color: var(--primary-dark);
+}
+
+.motd__meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6rem 0.9rem;
+  background: rgba(31, 111, 180, 0.08);
+  border-radius: 999px;
+  border: 1px solid rgba(31, 111, 180, 0.15);
+  color: var(--primary-dark);
+  font-weight: 600;
+}
+
+.motd__label {
+  opacity: 0.75;
+}
+
+.motd__timestamp {
+  font-variant-numeric: tabular-nums;
+}
+
+.motd__body {
+  position: relative;
+  padding-left: 1rem;
+  border-left: 3px solid rgba(23, 50, 75, 0.16);
+  color: var(--muted);
+  line-height: 1.9;
+  font-size: clamp(1rem, 1.8vw, 1.1rem);
+}
+
+.motd__body::before {
+  content: "\2728";
+  position: absolute;
+  left: -0.5rem;
+  top: -0.2rem;
+  font-size: 1.3rem;
+}
+
 .main {
   width: min(960px, 92%);
   margin: 0 auto 3rem;
@@ -928,6 +1000,23 @@ body::after {
 
 .letter-dialog__footer time {
   font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 768px) {
+  .motd {
+    padding: 1.5rem 1.4rem;
+    gap: 0.75rem;
+  }
+
+  .motd__meta {
+    width: 100%;
+    justify-content: space-between;
+    flex-wrap: wrap;
+  }
+
+  .motd__body {
+    padding-left: 0.75rem;
+  }
 }
 
 @media (max-width: 720px) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -78,6 +78,27 @@
       </div>
     </header>
 
+    <section class="motd" aria-labelledby="motd-title">
+      <div class="motd__header">
+        <div>
+          <p class="motd__eyebrow">Message of the day</p>
+          <h2 id="motd-title">📮 今日留言</h2>
+        </div>
+        <div class="motd__meta">
+          <span class="motd__label">写下的时间</span>
+          <time class="motd__timestamp" datetime="2025-02-20T21:30:00+08:00">2025/02/20 21:30 (UTC+8)</time>
+        </div>
+      </div>
+      <div class="motd__body">
+        <p>
+          从你回到熟悉环境起的未来十天，不会强求也不会打扰，我想可以找到一次合适的时间 电话里聊聊天。 一次就好<br />
+          你好则我安， 有机会的话，请告诉我你现在变得多么开心多么好。<br />
+          我会看好旧的能量保证它们不会流向你。<br />
+          如果没有机会的话， 也开心地祝一切安好 😀
+        </p>
+      </div>
+    </section>
+
     <main class="main">
 
       <section class="card encouragement" aria-labelledby="encouragement-title">


### PR DESCRIPTION
## Summary
- add a message-of-the-day panel beneath the hero title with the latest note and timestamp
- style the panel with gradient, timestamp badge, and responsive layout so it holds up on portrait screens

## Testing
- pip install -r requirements.txt *(fails in container due to proxy restrictions while attempting to install Flask)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692019a97338832a96fc3429cd3f4393)