### PR TITLE
Switch homepage to holiday greetings edition

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>1206 专属心灵休憩小客厅（归家途中版）</title>
+    <title>1206 专属心灵休憩小客厅（圣诞新年季祝福版）</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -69,38 +69,25 @@
       <div class="hero__content">
         <h1>
           欢迎回到 1206 专属心灵休憩小客厅
-          <span class="hero__edition">（归家途中版）</span>
+          <span class="hero__edition">（圣诞新年季祝福版）</span>
         </h1>
         <p>
-          一段消息可能会转瞬即逝，所以我希望能做一些能留存更久的东西，比如说这个小小页面。
-          愿你在这里放慢呼吸，温柔地，略带喜悦地触碰曾经的自己。不必担心，这次这个小客厅会一直无声陪伴。
+          圣诞和新年的灯光都已经点亮，想把祝福留在这里：圣诞新年快乐，恭喜通过 RN 注册护士的考试。
         </p>
+        <p>曾经努力希望实现的远方现在已经在脚下，愿你每一步都更自在、更闪亮。</p>
       </div>
     </header>
 
-    <section class="motd" aria-labelledby="motd-title">
-      <div class="motd__header">
-        <div>
-          <p class="motd__eyebrow">Message of the day</p>
-          <h2 id="motd-title">📮 今日留言</h2>
-        </div>
-        <div class="motd__meta">
-          <span class="motd__label">写下的时间</span>
-          <time class="motd__timestamp" datetime="2025-11-21T21:30:00+08:00">2025/11/21 21:30 (UTC+8)</time>
-        </div>
-      </div>
-      <div class="motd__body">
-        <p>
-          从你回到熟悉环境起的未来十天，don't think it's too much to be asked but 如果你感觉还好，我想在电话里听听你聊聊见闻和成长。<br />
-          一次就好 不会强求也不会多打扰<br />
-          你好则我安，我有荣幸的话，请告诉我你现在变得多么开心多么好。<br />
-          我一定会看好旧的能量 保证它们不会流向你。<br />
-          如果没有机会的话， 也开心地祝一切安好😊
-        </p>
-      </div>
-    </section>
-
     <main class="main">
+      <section class="card festive-blessing" aria-labelledby="festive-blessing-title">
+        <h2 id="festive-blessing-title">🎄 圣诞新年祝福</h2>
+        <p>
+          这是属于你的节日信笺：圣诞新年快乐，恭喜正式成为 RN 注册护士。你的坚持和温柔让冬夜有了光，也让未来的每一次守护都更笃定。
+        </p>
+        <p>
+          曾经努力希望实现的远方现在已经在脚下，愿你把这份勇气和荣耀装进行囊，去迎接下一段更自由、也更被祝福的旅程。
+        </p>
+      </section>
 
       <section class="card encouragement" aria-labelledby="encouragement-title">
         <div class="encouragement__media">


### PR DESCRIPTION
## Summary
- retitle the page as the Christmas and New Year blessing edition with refreshed hero copy
- remove the previous Message of the Day block
- add a festive greeting card celebrating the RN exam success and holiday wishes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944439d0604832a83b00b814679eed2)