### PR TITLE
Add logging for pass gate unlock events

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,10 +14,12 @@ DATA_DIR = Path(os.environ.get("DATA_DIRECTORY", "/etc/data")).resolve()
 VIDEO_DIR = Path(os.environ.get("VIDEO_DIRECTORY", "/opt/video")).resolve()
 LOG_FILE = DATA_DIR / "messages.log"
 UPLOAD_DIR = DATA_DIR / "uploads"
+PASS_GATE_LOG_FILE = DATA_DIR / "pass_gate.log"
 ALLOWED_IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
 ALLOWED_VIDEO_SUFFIXES = {".mp4", ".webm", ".mov", ".m4v"}
 EXPECTED_TOOL_ANSWER = "化身孤岛的鲸"
 ANSWER_FILE = Path(__file__).resolve().parent / "answer.txt"
+ALLOWED_PASSCODES = {"riesling"}
 
 
 def _iter_video_files() -> list[dict[str, str]]:
@@ -112,6 +114,51 @@ def guestbook() -> Response:
 
 @app.get("/health")
 def health() -> Response:
+    return jsonify({"status": "ok"})
+
+
+def _normalize_log_field(value: str | None) -> str:
+    if not value:
+        return "-"
+    return " ".join(str(value).split())
+
+
+@app.post("/pass-gate/log")
+def log_pass_gate_access() -> Response:
+    payload = request.get_json(silent=True) or {}
+    passcode = str(payload.get("passcode", "")).strip()
+
+    if not passcode:
+        return jsonify({"message": "需要输入口令才能解锁。"}), 400
+
+    if passcode.lower() not in ALLOWED_PASSCODES:
+        return jsonify({"message": "口令和提示不太匹配，请再试一次。"}), 403
+
+    timestamp = datetime.utcnow().isoformat(timespec="seconds") + "Z"
+    forwarded_for = request.headers.get("X-Forwarded-For", "")
+    client_ip = forwarded_for.split(",")[0].strip() if forwarded_for else (request.remote_addr or "")
+    user_agent = request.headers.get("User-Agent", "")
+    referrer = request.referrer or request.headers.get("Referer", "")
+    accept_language = request.headers.get("Accept-Language", "")
+    host = request.host or ""
+
+    try:
+        DATA_DIR.mkdir(parents=True, exist_ok=True)
+        with PASS_GATE_LOG_FILE.open("a", encoding="utf-8") as fp:
+            log_entry = (
+                f"{timestamp}\t"
+                f"passcode={_normalize_log_field(passcode)}\t"
+                f"ip={_normalize_log_field(client_ip)}\t"
+                f"host={_normalize_log_field(host)}\t"
+                f"path={_normalize_log_field(request.path)}\t"
+                f"referrer={_normalize_log_field(referrer)}\t"
+                f"user_agent={_normalize_log_field(user_agent)}\t"
+                f"accept_language={_normalize_log_field(accept_language)}"
+            )
+            fp.write(log_entry + "\n")
+    except OSError:
+        return jsonify({"message": "记录登录信息时出现问题，请稍后再试。"}), 500
+
     return jsonify({"status": "ok"})
 
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -17,7 +17,6 @@ document.addEventListener("DOMContentLoaded", () => {
   const passGateFeedback = document.getElementById("pass-gate-feedback");
   const passGateSubmitButton = passGateForm?.querySelector("button[type='submit']");
   const PASS_GATE_KEY = "pass-gate-unlocked";
-  const allowedPasscodes = ["riesling"];
   const PASS_GATE_COOLDOWN_MS = 5000;
   let passGateCooldownTimer = null;
 
@@ -39,8 +38,6 @@ document.addEventListener("DOMContentLoaded", () => {
       }
     }
   };
-
-  const validatePasscode = (value) => allowedPasscodes.includes(value.trim().toLowerCase());
 
   const setPassGateControlsDisabled = (disabled) => {
     if (passGateInput) {
@@ -92,7 +89,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   if (passGateForm && passGateInput) {
-    passGateForm.addEventListener("submit", (event) => {
+    passGateForm.addEventListener("submit", async (event) => {
       event.preventDefault();
       if (passGateInput.disabled) {
         return;
@@ -102,14 +99,31 @@ document.addEventListener("DOMContentLoaded", () => {
         setPassGateMessage("需要先输入口令。", true);
         return;
       }
-      if (!validatePasscode(value)) {
-        startPassGateCooldown();
-        return;
+      setPassGateMessage("正在验证口令，请稍候...");
+      try {
+        const response = await fetch("/pass-gate/log", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ passcode: value }),
+        });
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => null);
+          const errorMessage = errorData?.message || "口令和提示不太匹配，请稍后再试。";
+          setPassGateMessage(errorMessage, true);
+          startPassGateCooldown();
+          return;
+        }
+
+        setPassGateMessage("口令正确，正在解锁，欢迎回来。");
+        window.setTimeout(() => {
+          unlockPassGate();
+        }, 300);
+      } catch (error) {
+        setPassGateMessage("验证口令时遇到问题，请稍后再试。", true);
       }
-      setPassGateMessage("口令正确，正在解锁，欢迎回来。");
-      window.setTimeout(() => {
-        unlockPassGate();
-      }, 300);
     });
   }
 


### PR DESCRIPTION
## Summary
- add a backend endpoint to validate the pass gate passcode and append detailed unlock records to /etc/data
- update the pass gate form to verify passcodes via the server and unlock after a successful log write

## Testing
- python -m compileall app.py static/js/app.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c8410ae68832a97449f9ac8cb4a9f)